### PR TITLE
Disable Statement cache

### DIFF
--- a/lib/Mojo/mysql.pm
+++ b/lib/Mojo/mysql.pm
@@ -149,8 +149,8 @@ L<Mojo::mysql> inherits all events from L<Mojo::EventEmitter> and can emit the
 following new ones.
 
 =head2 connection
-  $pg->on(connection => sub {
-    my ($pg, $dbh) = @_;
+  $mysql->on(connection => sub {
+    my ($mysql, $dbh) = @_;
     ...
   });
 
@@ -200,7 +200,7 @@ C<mysql_auto_reconnect> is never enabled, L<Mojo::mysql> takes care of dead conn
 
 C<AutoCommit> cannot not be disabled, use $db->L<begin|Mojo::mysql::Database/begin> to manage transactions.
 
-C<RaiseError> is disabled event loop for asyncronous queries.
+C<RaiseError> is disabled in event loop for asyncronous queries.
 
 =head2 password
 

--- a/lib/Mojo/mysql.pm
+++ b/lib/Mojo/mysql.pm
@@ -15,7 +15,7 @@ has migrations      => sub {
   weaken $migrations->{mysql};
   return $migrations;
 };
-has options => sub { {AutoCommit => 1, PrintError => 0, RaiseError => 1} };
+has options => sub { {mysql_enable_utf8 => 1, AutoCommit => 1, PrintError => 0, RaiseError => 1} };
 has [qw(password username)] => '';
 
 our $VERSION = '0.04';
@@ -153,7 +153,7 @@ following new ones.
     my ($pg, $dbh) = @_;
     ...
   });
-  
+
 Emitted when a new database connection has been established.
 
 =head1 ATTRIBUTES
@@ -191,10 +191,16 @@ easily.
 =head2 options
 
   my $options = $mysql->options;
-  $mysql      = $mysql->options({AutoCommit => 1});
+  $mysql      = $mysql->options({mysql_use_result => 1});
 
-Options for database handles, defaults to activating C<AutoCommit> as well as
+Options for database handles, defaults to activating C<mysql_enable_utf8>, C<AutoCommit> as well as
 C<RaiseError> and deactivating C<PrintError>.
+
+C<mysql_auto_reconnect> is never enabled, L<Mojo::mysql> takes care of dead connections.
+
+C<AutoCommit> cannot not be disabled, use $db->L<begin|Mojo::mysql::Database/begin> to manage transactions.
+
+C<RaiseError> is disabled event loop for asyncronous queries.
 
 =head2 password
 

--- a/lib/Mojo/mysql.pm
+++ b/lib/Mojo/mysql.pm
@@ -72,6 +72,10 @@ sub _dequeue {
   # you, silently, but only if certain env vars are set
   # hint: force-set mysql_auto_reconnect or whatever it's called to 0
   $dbh->{mysql_auto_reconnect} = 0;
+  # Maintain Commits with Mojo::mysql::Transaction
+  $dbh->{AutoCommit} = 1;
+
+  $self->emit(connection => $dbh);
   [$dbh];
 }
 
@@ -125,7 +129,7 @@ L<Mojo::mysql> is a tiny wrapper around L<DBD::mysql> that makes
 L<MySQL|http://www.mysql.org> a lot of fun to use with the
 L<Mojolicious|http://mojolicio.us> real-time web framework.
 
-Database and statement handles are cached automatically, so they can be reused
+Database handles are cached automatically, so they can be reused
 transparently to increase performance. While all I/O operations are performed
 blocking, you can wait for long running queries asynchronously, allowing the
 L<Mojo::IOLoop> event loop to perform other tasks in the meantime. Since
@@ -138,6 +142,19 @@ object safely.
 
 Note that this whole distribution is EXPERIMENTAL and will change without
 warning!
+
+=head1 EVENTS
+
+L<Mojo::mysql> inherits all events from L<Mojo::EventEmitter> and can emit the
+following new ones.
+
+=head2 connection
+  $pg->on(connection => sub {
+    my ($pg, $dbh) = @_;
+    ...
+  });
+  
+Emitted when a new database connection has been established.
 
 =head1 ATTRIBUTES
 
@@ -195,7 +212,7 @@ Database username, defaults to an empty string.
 
 =head1 METHODS
 
-L<Mojo::mysql> inherits all methods from L<Mojo::Base> and implements the
+L<Mojo::mysql> inherits all methods from L<Mojo::EventEmitter> and implements the
 following new ones.
 
 =head2 db

--- a/lib/Mojo/mysql/Database.pm
+++ b/lib/Mojo/mysql/Database.pm
@@ -175,6 +175,12 @@ Disconnect database handle and prevent it from getting cached again.
 
 Execute a statement and discard its result.
 
+=head2 pid
+
+  my $pid = $db->pid;
+
+Return the connection id of the backend server process.
+
 =head2 ping
 
   my $bool = $db->ping;

--- a/lib/Mojo/mysql/Database.pm
+++ b/lib/Mojo/mysql/Database.pm
@@ -99,7 +99,7 @@ sub _watch {
       my $result = do { local $sth->{RaiseError} = 0; $sth->mysql_async_result; };
       my $err = defined $result ? undef : $dbh->errstr;
 
-      $self->$cb($err, Mojo::mysql::Results->new(dbh => $self, sth => $sth));
+      $self->$cb($err, Mojo::mysql::Results->new(db => $self, sth => $sth));
       $self->_next;
       $self->_unwatch unless $self->backlog;
     }

--- a/lib/Mojo/mysql/Migrations.pm
+++ b/lib/Mojo/mysql/Migrations.pm
@@ -118,7 +118,7 @@ C<-- VERSION UP/DOWN>.
 
   -- 1 up
   create table messages (message text);
-  insert into messages values ('I â™¥ Mojolicious!');
+  insert into messages values ('I ♥ Mojolicious!');
   -- 1 down
   drop table messages;
   -- 2 up (...you can comment freely here...)
@@ -175,7 +175,7 @@ L<Mojo::Loader>, defaults to using the caller class and L</"name">.
   @@ migrations
   -- 1 up
   create table messages (message text);
-  insert into messages values ('I â™¥ Mojolicious!');
+  insert into messages values ('I ♥ Mojolicious!');
   -- 1 down
   drop table messages;
 

--- a/lib/Mojo/mysql/Migrations.pm
+++ b/lib/Mojo/mysql/Migrations.pm
@@ -46,7 +46,7 @@ sub migrate {
   return $self if $self->_active($db) == $target;
 
   # Lock migrations table and check version again
-  local @{$db->dbh}{qw(AutoCommit RaiseError)} = (1, 1);
+  local $db->dbh->{RaiseError} = 1;
   my $tx = $db->begin;
 
   return $self if (my $active = $self->_active($db)) == $target;
@@ -77,11 +77,12 @@ sub _active {
 
   my $dbh  = $db->dbh;
   my $name = $self->name;
-  local @$dbh{qw(AutoCommit RaiseError)} = (1, 0);
+  local $dbh->{RaiseError} = 0;
   my $results = $db->query('select version from mojo_migrations where name = ?', $name);
   if (my $next = $results->array) { return $next->[0] }
 
-  local @$dbh{qw(AutoCommit RaiseError)} = (1, 1);
+  local $dbh->{RaiseError} = 1;
+
   $db->query(
     'create table if not exists mojo_migrations (
        name    varchar(255) unique not null,

--- a/lib/Mojo/mysql/Results.pm
+++ b/lib/Mojo/mysql/Results.pm
@@ -4,12 +4,7 @@ use Mojo::Base -base;
 use Mojo::Collection;
 use Mojo::Util 'tablify';
 
-has [qw(db sth)];
-
-sub DESTROY {
-  my $self = shift;
-  if ((my $db = $self->db) && (my $sth = $self->sth)) { $db->_enqueue($sth) }
-}
+has 'sth';
 
 sub array { shift->sth->fetchrow_arrayref }
 
@@ -47,13 +42,6 @@ L<Mojo::mysql::Database>.
 =head1 ATTRIBUTES
 
 L<Mojo::mysql::Results> implements the following attributes.
-
-=head2 db
-
-  my $db   = $results->db;
-  $results = $results->db(Mojo::mysql::Database->new);
-
-L<Mojo::mysql::Database> object these results belong to.
 
 =head2 sth
 

--- a/lib/Mojo/mysql/Results.pm
+++ b/lib/Mojo/mysql/Results.pm
@@ -4,12 +4,12 @@ use Mojo::Base -base;
 use Mojo::Collection;
 use Mojo::Util 'tablify';
 
-has dbh => undef;
+has db => undef;
 has 'sth';
 
 sub DESTROY {
   my $self = shift;
-  $self->dbh ? $self->dbh->_destroy($self->sth) : $self->sth->finish;
+  $self->db ? $self->db->_destroy($self->sth) : $self->sth->finish;
 }
 
 sub array { shift->sth->fetchrow_arrayref }
@@ -48,6 +48,13 @@ L<Mojo::mysql::Database>.
 =head1 ATTRIBUTES
 
 L<Mojo::mysql::Results> implements the following attributes.
+
+=head2 db
+
+  my $db   = $results->db;
+  $results = $results->db(Mojo::mysql::Database->new);
+
+L<Mojo::mysql::Database> object these results belong to.
 
 =head2 sth
 

--- a/lib/Mojo/mysql/Results.pm
+++ b/lib/Mojo/mysql/Results.pm
@@ -4,7 +4,13 @@ use Mojo::Base -base;
 use Mojo::Collection;
 use Mojo::Util 'tablify';
 
+has dbh => undef;
 has 'sth';
+
+sub DESTROY {
+  my $self = shift;
+  $self->dbh ? $self->dbh->_destroy($self->sth) : $self->sth->finish;
+}
 
 sub array { shift->sth->fetchrow_arrayref }
 

--- a/lib/Mojo/mysql/Results.pm
+++ b/lib/Mojo/mysql/Results.pm
@@ -4,13 +4,7 @@ use Mojo::Base -base;
 use Mojo::Collection;
 use Mojo::Util 'tablify';
 
-has db => undef;
 has 'sth';
-
-sub DESTROY {
-  my $self = shift;
-  $self->db ? $self->db->_destroy($self->sth) : $self->sth->finish;
-}
 
 sub array { shift->sth->fetchrow_arrayref }
 
@@ -48,13 +42,6 @@ L<Mojo::mysql::Database>.
 =head1 ATTRIBUTES
 
 L<Mojo::mysql::Results> implements the following attributes.
-
-=head2 db
-
-  my $db   = $results->db;
-  $results = $results->db(Mojo::mysql::Database->new);
-
-L<Mojo::mysql::Database> object these results belong to.
 
 =head2 sth
 

--- a/t/database.t
+++ b/t/database.t
@@ -113,17 +113,6 @@ is $mysql->db->dbh, $dbh, 'same database handle';
 $mysql->db->disconnect;
 isnt $mysql->db->dbh, $dbh, 'different database handles';
 
-# Statement cache
-$db = $mysql->db;
-is $db->max_statements, 10, 'right default';
-my $sth = $db->max_statements(2)->query('select 3 as three')->sth;
-is $db->query('select 3 as three')->sth,   $sth, 'same statement handle';
-isnt $db->query('select 4 as four')->sth,  $sth, 'different statement handles';
-is $db->query('select 3 as three')->sth,   $sth, 'same statement handle';
-isnt $db->query('select 5 as five')->sth,  $sth, 'different statement handles';
-isnt $db->query('select 6 as six')->sth,   $sth, 'different statement handles';
-isnt $db->query('select 3 as three')->sth, $sth, 'different statement handles';
-
 # Fork safety
 $dbh = $mysql->db->dbh;
 {

--- a/t/database.t
+++ b/t/database.t
@@ -115,6 +115,7 @@ Mojo::IOLoop->delay(
   },
   sub {
     my ($delay, $err_two, $two, $err_again, $again) = @_;
+    push @$result, $db->query('select 1 as one')->hashes->first;
     $fail ||= $err_two || $err_again;
     push @$result, $two->hashes->first, $again->hashes->first;
     $db->query('select 3 as three' => $delay->begin);
@@ -126,7 +127,7 @@ Mojo::IOLoop->delay(
   }
 )->wait;
 ok !$fail, 'no error' or diag "err=$fail";
-is_deeply $result, [{one => 1}, {two => 2}, {two => 2}, {three => 3}], 'right structure';
+is_deeply $result, [{one => 1}, {one => 1}, {two => 2}, {two => 2}, {three => 3}], 'right structure';
 
 # Connection cache
 is $mysql->max_connections, 5, 'right default';

--- a/t/database.t
+++ b/t/database.t
@@ -14,42 +14,42 @@ my $mysql = Mojo::mysql->new;
 is $mysql->dsn,      'dbi:mysql:dbname=test', 'right data source';
 is $mysql->username, '',                      'no username';
 is $mysql->password, '',                      'no password';
-is_deeply $mysql->options, {AutoCommit => 1, PrintError => 0, RaiseError => 1}, 'right options';
+is_deeply $mysql->options, {mysql_enable_utf8 => 1, AutoCommit => 1, PrintError => 0, RaiseError => 1}, 'right options';
 
 # Minimal connection string
 $mysql = Mojo::mysql->new('mysql:///test1');
 is $mysql->dsn,      'dbi:mysql:dbname=test1', 'right data source';
 is $mysql->username, '',                       'no username';
 is $mysql->password, '',                       'no password';
-is_deeply $mysql->options, {AutoCommit => 1, PrintError => 0, RaiseError => 1}, 'right options';
+is_deeply $mysql->options, {mysql_enable_utf8 => 1, AutoCommit => 1, PrintError => 0, RaiseError => 1}, 'right options';
 
 # Connection string with host and port
 $mysql = Mojo::mysql->new('mysql://127.0.0.1:8080/test2');
 is $mysql->dsn,      'dbi:mysql:dbname=test2;host=127.0.0.1;port=8080', 'right data source';
 is $mysql->username, '',                                                'no username';
 is $mysql->password, '',                                                'no password';
-is_deeply $mysql->options, {AutoCommit => 1, PrintError => 0, RaiseError => 1}, 'right options';
+is_deeply $mysql->options, {mysql_enable_utf8 => 1, AutoCommit => 1, PrintError => 0, RaiseError => 1}, 'right options';
 
 # Connection string username but without host
 $mysql = Mojo::mysql->new('mysql://root@/test3');
 is $mysql->dsn,      'dbi:mysql:dbname=test3', 'right data source';
 is $mysql->username, 'root',                   'right username';
 is $mysql->password, '',                       'no password';
-is_deeply $mysql->options, {AutoCommit => 1, PrintError => 0, RaiseError => 1}, 'right options';
+is_deeply $mysql->options, {mysql_enable_utf8 => 1, AutoCommit => 1, PrintError => 0, RaiseError => 1}, 'right options';
 
 # Connection string with unix domain socket and options
 $mysql = Mojo::mysql->new('mysql://x1:y2@%2ftmp%2fmysql.sock/test4?PrintError=1&RaiseError=0');
 is $mysql->dsn,      'dbi:mysql:dbname=test4;host=/tmp/mysql.sock', 'right data source';
 is $mysql->username, 'x1',                                          'right username';
 is $mysql->password, 'y2',                                          'right password';
-is_deeply $mysql->options, {AutoCommit => 1, PrintError => 1, RaiseError => 0}, 'right options';
+is_deeply $mysql->options, {mysql_enable_utf8 => 1, AutoCommit => 1, PrintError => 1, RaiseError => 0}, 'right options';
 
 # Connection string with lots of zeros
 $mysql = Mojo::mysql->new('mysql://0:0@/0?RaiseError=0');
 is $mysql->dsn,      'dbi:mysql:dbname=0', 'right data source';
 is $mysql->username, '0',                  'right username';
 is $mysql->password, '0',                  'right password';
-is_deeply $mysql->options, {AutoCommit => 1, PrintError => 0, RaiseError => 0}, 'right options';
+is_deeply $mysql->options, {mysql_enable_utf8 => 1, AutoCommit => 1, PrintError => 0, RaiseError => 0}, 'right options';
 
 # Invalid connection string
 eval { Mojo::mysql->new('http://localhost:3000/test') };

--- a/t/results.t
+++ b/t/results.t
@@ -15,6 +15,7 @@ my $db    = $mysql->db->do(
      name varchar(255)
    )'
 );
+$db->do('truncate table results_test');
 $db->query('insert into results_test (name) values (?)', $_) for qw(foo bar);
 
 # Result methods

--- a/t/results.t
+++ b/t/results.t
@@ -18,7 +18,8 @@ my $db    = $mysql->db->do(
 $db->query('insert into results_test (name) values (?)', $_) for qw(foo bar);
 
 # Result methods
-is_deeply $db->query('select * from results_test')->rows, 2, 'two rows';
+my $rows = $db->dbh->{mysql_use_result} ? 0 : 2;
+is_deeply $db->query('select * from results_test')->rows, $rows, 'two rows';
 is_deeply $db->query('select * from results_test')->columns, ['id', 'name'], 'right structure';
 is_deeply $db->query('select * from results_test')->array,   [1,    'foo'],  'right structure';
 is_deeply [$db->query('select * from results_test')->arrays->each], [[1, 'foo'], [2, 'bar']], 'right structure';

--- a/t/utf8.t
+++ b/t/utf8.t
@@ -1,0 +1,34 @@
+use Mojo::Base -strict;
+
+BEGIN { $ENV{MOJO_REACTOR} = 'Mojo::Reactor::Poll' }
+
+use Test::More;
+
+plan skip_all => 'set TEST_ONLINE to enable this test' unless $ENV{TEST_ONLINE};
+
+use Mojo::mysql;
+
+my $mysql = Mojo::mysql->new($ENV{TEST_ONLINE});
+my $db    = $mysql->db->do(
+  'create table if not exists results_test (
+     id serial primary key,
+     name varchar(255) charset utf8
+   )'
+);
+$db->do('truncate table results_test');
+$db->query('insert into results_test (name) values (?)', $_) for qw(☺ ☻);
+
+# Result methods
+my $rows = $db->dbh->{mysql_use_result} ? 0 : 2;
+is_deeply $db->query('select * from results_test')->rows, $rows, 'two rows';
+is_deeply $db->query('select * from results_test')->columns, ['id', 'name'], 'right structure';
+is_deeply $db->query('select * from results_test')->array,   [1,    '☺'],  'right structure';
+is_deeply [$db->query('select * from results_test')->arrays->each], [[1, '☺'], [2, '☻']], 'right structure';
+is_deeply $db->query('select * from results_test')->hash, {id => 1, name => '☺'}, 'right structure';
+is_deeply [$db->query('select * from results_test')->hashes->each],
+  [{id => 1, name => '☺'}, {id => 2, name => '☻'}], 'right structure';
+is $mysql->db->query('select * from results_test')->text, "1  ☺\n2  ☻\n", 'right text';
+
+$db->do('drop table results_test');
+
+done_testing();


### PR DESCRIPTION
Do not cache statements in Mojo::mysql::Database.
$sth->finish is implicitly called when $sth is destroyed, fixing problem with mysql_use_result
Synced changes from Mojo::Pg
