### PR TITLE
new Mojo::Loader API

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -20,7 +20,7 @@ WriteMakefile(
 ,
   PREREQ_PM => {
   'DBD::mysql' => '4.019',
-  'Mojolicious' => '5.49'
+  'Mojolicious' => '5.81'
 }
 ,
   test => { TESTS => 't/*.t' },

--- a/cpanfile
+++ b/cpanfile
@@ -1,3 +1,3 @@
-requires 'Mojolicious' => '5.49';
+requires 'Mojolicious' => '5.81';
 requires 'DBD::mysql' => '4.019';
 test_requires 'Test::More' => '0.90';

--- a/lib/Mojo/mysql.pm
+++ b/lib/Mojo/mysql.pm
@@ -149,6 +149,7 @@ L<Mojo::mysql> inherits all events from L<Mojo::EventEmitter> and can emit the
 following new ones.
 
 =head2 connection
+
   $mysql->on(connection => sub {
     my ($mysql, $dbh) = @_;
     ...

--- a/lib/Mojo/mysql/Migrations.pm
+++ b/lib/Mojo/mysql/Migrations.pm
@@ -2,7 +2,7 @@ package Mojo::mysql::Migrations;
 use Mojo::Base -base;
 
 use Carp 'croak';
-use Mojo::Loader;
+use Mojo::Loader 'data_section';
 use Mojo::Util 'slurp';
 
 use constant DEBUG => $ENV{MOJO_MIGRATIONS_DEBUG} || 0;
@@ -14,7 +14,7 @@ sub active { $_[0]->_active($_[0]->mysql->db) }
 
 sub from_data {
   my ($self, $class, $name) = @_;
-  return $self->from_string(Mojo::Loader->new->data($class //= caller, $name // $self->name));
+  return $self->from_string(data_section($class //= caller, $name // $self->name));
 }
 
 sub from_file { shift->from_string(slurp pop) }


### PR DESCRIPTION
object-oriented Mojo::Loader API is deprecated in Mojolicious 5.81
