### PR TITLE
Deprecate db, some new methods

### DIFF
--- a/lib/Mojo/mysql/Database.pm
+++ b/lib/Mojo/mysql/Database.pm
@@ -5,6 +5,7 @@ use DBD::mysql;
 use Mojo::IOLoop;
 use Mojo::mysql::Results;
 use Mojo::mysql::Transaction;
+use Mojo::Util 'deprecated';
 use Scalar::Util 'weaken';
 
 has [qw(dbh mysql)];
@@ -32,7 +33,10 @@ sub disconnect {
   $self->dbh->disconnect;
 }
 
+# DEPRECATED!
 sub do {
+  deprecated 'Mojo::mysql::Database::do is DEPRECATED'
+    . ' in favor of Mojo::mysql::Database::query';
   my $self = shift;
   $self->dbh->do(@_);
   return $self;

--- a/lib/Mojo/mysql/Migrations.pm
+++ b/lib/Mojo/mysql/Migrations.pm
@@ -65,30 +65,35 @@ sub migrate {
   }
 
   warn "-- Migrate ($active -> $target)\n$sql\n" if DEBUG;
-  chop($sql);
-  $db->query($_) for split(';', $sql);
-  $sql = "update mojo_migrations set version = ? where name = ?;";
-  $db->query($sql, $target, $self->name) and $tx->commit;
+  eval {
+    foreach my $q (split(';', $sql)) {
+      next if $q =~ /^\s*$/s;
+      $db->query($q);
+    }
+    $db->query("update mojo_migrations set version = ? where name = ?", $target, $self->name);
+  };
+  if (my $error = $@) {
+    undef $tx;
+    die $error;
+  }
+  $tx->commit;
   return $self;
 }
 
 sub _active {
   my ($self, $db) = @_;
 
-  my $dbh  = $db->dbh;
   my $name = $self->name;
-  local $dbh->{RaiseError} = 0;
-  my $results = $db->query('select version from mojo_migrations where name = ?', $name);
-  if (my $next = $results->array) { return $next->[0] }
-
-  local $dbh->{RaiseError} = 1;
+  my $results = eval { $db->query('select version from mojo_migrations where name = ?', $name) };
+  my $error = $@;
+  if ($results and my $next = $results->array) { return $next->[0] }
 
   $db->query(
     'create table if not exists mojo_migrations (
        name    varchar(255) unique not null,
        version bigint not null
      )'
-  ) if $results->sth->err;
+  ) if $error;
   $db->query('insert into mojo_migrations values (?, ?)', $name, 0);
 
   return 0;

--- a/lib/Mojo/mysql/Results.pm
+++ b/lib/Mojo/mysql/Results.pm
@@ -20,6 +20,19 @@ sub rows { shift->sth->rows }
 
 sub text { tablify shift->arrays }
 
+sub more_results { shift->sth->more_results }
+
+sub affected_rows { shift->{affected_rows} }
+
+sub warnings_count { shift->sth->{mysql_warning_count} }
+
+sub last_insert_id { shift->sth->{mysql_insertid} }
+
+sub err { shift->sth->err }
+
+sub errstr { shift->sth->errstr }
+
+sub state { shift->sth->state }
 1;
 
 =encoding utf8
@@ -98,6 +111,58 @@ Number of rows.
   my $text = $results->text;
 
 Fetch all rows and turn them into a table with L<Mojo::Util/"tablify">.
+
+=head2 more_results
+
+  do {
+    my $columns = $results->columns;
+    my $arrays = $results->arrays;
+  } while ($results->more_results);
+
+Handle multiple results.
+
+=head2 affected_rows
+
+  my $affected = $results->affected_rows;
+
+Number of affected rows by the query.
+The number reported is dependant from C<found_rows> option in L<Mojo::mysql>.
+For example
+
+  UPDATE $table SET id = 1 WHERE id = 1
+
+would return 1 if C<found_rows> is set, and 0 otherwise.
+
+=head2 last_insert_id
+
+  my $last_id = $results->last_insert_id;
+
+That value of C<AUTO_INCREMENT> column if executed query was C<INSERT> in a table with
+C<AUTO_INCREMENT> column.
+
+=head2 warnings_count
+
+  my $warnings = $results->warnings_count;
+
+Number of warnings raised by the executed query.
+
+=head2 err
+
+  my $err = $results->err;
+
+Error code receieved.
+
+=head2 state
+
+  my $state = $results->state;
+
+Error state receieved.
+
+=head2 errstr
+
+  my $errstr = $results->errstr;
+
+Error message receieved.
 
 =head1 SEE ALSO
 

--- a/t/migrations.t
+++ b/t/migrations.t
@@ -87,7 +87,7 @@ is $mysql2->migrations->migrate(0)->active, 0, 'active version is 0';
 eval { $mysql->migrations->migrate(23) };
 like $@, qr/Version 23 has no migration/, 'right error';
 
-$mysql->db->do('drop table mojo_migrations');
+$mysql->db->query('drop table mojo_migrations');
 
 done_testing();
 

--- a/t/mysql_lite_app.t
+++ b/t/mysql_lite_app.t
@@ -4,26 +4,22 @@ BEGIN { $ENV{MOJO_REACTOR} = 'Mojo::Reactor::Poll' }
 
 use Test::More;
 
-plan skip_all => 'set TEST_ONLINE to enable this test' unless $ENV{TEST_ONLINE};
+plan skip_all => 'set TEST_ONLINE to enable this test'
+  unless $ENV{TEST_ONLINE};
 
 use Mojo::mysql;
 use Mojolicious::Lite;
 use Test::Mojo;
 
-helper mysql => sub {
-  state $mysql = do {
-    my $c = Mojo::mysql->new($ENV{TEST_ONLINE});
-    $c->options->{mysql_enable_utf8} = 1;
-    $c;
-  };
-};
+helper mysql => sub { state $mysql = Mojo::mysql->new($ENV{TEST_ONLINE}) };
 
-app->mysql->db->do('create table if not exists app_test (stuff varchar(255)) COLLATE = utf8_bin')
-  ->do("insert into app_test values ('I ♥ Mojolicious!')");
+app->mysql->migrations->name('app_test')->from_data->migrate;
 
 get '/blocking' => sub {
-  my $c = shift;
-  $c->render(text => $c->mysql->db->query('select * from app_test')->hash->{stuff});
+  my $c  = shift;
+  my $db = $c->mysql->db;
+  $c->res->headers->header('X-PID' => $db->pid);
+  $c->render(text => $db->query('select * from app_test')->hash->{stuff});
 };
 
 get '/non-blocking' => sub {
@@ -31,21 +27,39 @@ get '/non-blocking' => sub {
   $c->mysql->db->query(
     'select * from app_test' => sub {
       my ($db, $err, $results) = @_;
+      $c->res->headers->header('X-PID' => $db->pid);
       $c->render(text => $results->hash->{stuff});
     }
   );
 };
 
-# Make sure database connections are idle for a bit
 my $t = Test::Mojo->new;
-$t->ua->max_connections(0);
 
-# Blocking select (twice to allow connection reuse)
-$t->get_ok('/blocking')->status_is(200)->content_is('I ♥ Mojolicious!');
-$t->get_ok('/blocking')->status_is(200)->content_is('I ♥ Mojolicious!');
+# Make sure migrations are not served as static files
+$t->get_ok('/app_test')->status_is(404);
 
-# Non-blocking select
-$t->get_ok('/non-blocking')->status_is(200)->content_is('I ♥ Mojolicious!');
-$t->app->mysql->db->do('drop table app_test');
+# Blocking select (with connection reuse)
+$t->get_ok('/blocking')->status_is(200)->content_is('I ♥ Mojolicious!');
+my $pid = $t->tx->res->headers->header('X-PID');
+$t->get_ok('/blocking')->status_is(200)->header_is('X-PID', $pid)
+  ->content_is('I ♥ Mojolicious!');
+
+# Non-blocking select (with connection reuse)
+$t->get_ok('/non-blocking')->status_is(200)->header_is('X-PID', $pid)
+  ->content_is('I ♥ Mojolicious!');
+$t->get_ok('/non-blocking')->status_is(200)->header_is('X-PID', $pid)
+  ->content_is('I ♥ Mojolicious!');
+$t->app->mysql->migrations->migrate(0);
 
 done_testing();
+
+__DATA__
+@@ app_test
+-- 1 up
+create table if not exists app_test (stuff text);
+
+-- 2 up
+insert into app_test values ('I ♥ Mojolicious!');
+
+-- 1 down
+drop table app_test;

--- a/t/results.t
+++ b/t/results.t
@@ -4,47 +4,64 @@ BEGIN { $ENV{MOJO_REACTOR} = 'Mojo::Reactor::Poll' }
 
 use Test::More;
 
-plan skip_all => 'set TEST_ONLINE to enable this test' unless $ENV{TEST_ONLINE};
+plan skip_all => 'set TEST_ONLINE to enable this test'
+  unless $ENV{TEST_ONLINE};
 
 use Mojo::mysql;
 
 my $mysql = Mojo::mysql->new($ENV{TEST_ONLINE});
-my $db    = $mysql->db->do(
+my $db = $mysql->db;
+$db->query(
   'create table if not exists results_test (
-     id serial primary key,
-     name varchar(255)
+     id   serial primary key,
+     name text
    )'
 );
-$db->do('truncate table results_test');
 $db->query('insert into results_test (name) values (?)', $_) for qw(foo bar);
 
 # Result methods
-my $rows = $db->dbh->{mysql_use_result} ? 0 : 2;
-is_deeply $db->query('select * from results_test')->rows, $rows, 'two rows';
-is_deeply $db->query('select * from results_test')->columns, ['id', 'name'], 'right structure';
-is_deeply $db->query('select * from results_test')->array,   [1,    'foo'],  'right structure';
-is_deeply [$db->query('select * from results_test')->arrays->each], [[1, 'foo'], [2, 'bar']], 'right structure';
-is_deeply $db->query('select * from results_test')->hash, {id => 1, name => 'foo'}, 'right structure';
-is_deeply [$db->query('select * from results_test')->hashes->each],
+is_deeply $db->query('select * from results_test')->rows, 2, 'two rows';
+is_deeply $db->query('select * from results_test')->columns, ['id', 'name'],
+  'right structure';
+is_deeply $db->query('select * from results_test')->array, [1, 'foo'],
+  'right structure';
+is_deeply $db->query('select * from results_test')->arrays->to_array,
+  [[1, 'foo'], [2, 'bar']], 'right structure';
+is_deeply $db->query('select * from results_test')->hash,
+  {id => 1, name => 'foo'}, 'right structure';
+is_deeply $db->query('select * from results_test')->hashes->to_array,
   [{id => 1, name => 'foo'}, {id => 2, name => 'bar'}], 'right structure';
-is $mysql->db->query('select * from results_test')->text, "1  foo\n2  bar\n", 'right text';
+is $mysql->db->query('select * from results_test')->text, "1  foo\n2  bar\n",
+  'right text';
 
 # Transactions
 {
   my $tx = $db->begin;
-  $db->do("insert into results_test (name) values ('tx1')")->do("insert into results_test (name) values ('tx1')");
+  $db->query("insert into results_test (name) values ('tx1')");
+  $db->query("insert into results_test (name) values ('tx1')");
   $tx->commit;
-}
-
+};
+is_deeply $db->query('select * from results_test where name = ?', 'tx1')
+  ->hashes->to_array, [{id => 3, name => 'tx1'}, {id => 4, name => 'tx1'}],
+  'right structure';
 {
   my $tx = $db->begin;
-  $db->do("insert into results_test (name) values ('tx2')")->do("insert into results_test (name) values ('tx2')")
-}
+  $db->query("insert into results_test (name) values ('tx2')");
+  $db->query("insert into results_test (name) values ('tx2')");
+};
+is_deeply $db->query('select * from results_test where name = ?', 'tx2')
+  ->hashes->to_array, [], 'no results';
+eval {
+  my $tx = $db->begin;
+  $db->query("insert into results_test (name) values ('tx3')");
+  $db->query("insert into results_test (name) values ('tx3')");
+  $db->query('does_not_exist');
+  $tx->commit;
+};
+like $@, qr/does_not_exist/, 'right error';
+is_deeply $db->query('select * from results_test where name = ?', 'tx3')
+  ->hashes->to_array, [], 'no results';
 
-is_deeply [$db->query('select * from results_test where name = ?', 'tx1')->hashes->each],
-  [{id => 3, name => 'tx1'}, {id => 4, name => 'tx1'}], 'right structure';
-is_deeply [$db->query('select * from results_test where name = ?', 'tx2')->hashes->each], [], 'no results';
-
-$db->do('drop table results_test');
+$db->query('drop table results_test');
 
 done_testing();

--- a/t/results_methods.t
+++ b/t/results_methods.t
@@ -1,0 +1,77 @@
+use Mojo::Base -strict;
+
+BEGIN { $ENV{MOJO_REACTOR} = 'Mojo::Reactor::Poll' }
+
+use Test::More;
+
+plan skip_all => 'set TEST_ONLINE to enable this test'
+  unless $ENV{TEST_ONLINE};
+
+use Mojo::IOLoop;
+use Mojo::mysql;
+
+my $mysql = Mojo::mysql->new($ENV{TEST_ONLINE});
+$mysql->options->{mysql_client_found_rows} = 0;
+my $db = $mysql->db;
+$db->query(
+  'create table if not exists results_test (
+     id   integer auto_increment primary key,
+     name text
+   )'
+);
+$db->query('truncate table results_test');
+
+my $res = $db->query('insert into results_test (name) values (?)', 'foo');
+is $res->affected_rows, 1, 'right affected_rows';
+is $res->last_insert_id, 1, 'right last_insert_id';
+is $res->warnings_count, 0, 'no warnings';
+is $res->err, undef, 'no error';
+is $res->errstr, undef, 'no error';
+is $res->state, '', 'no state';
+
+
+$res = $db->query('insert into results_test (name) values (?)', 'bar');
+is $res->affected_rows, 1, 'right affected_rows';
+is $res->last_insert_id, 2, 'right last_insert_id';
+is $res->warnings_count, 0, 'no warnings';
+
+
+is $db->query('update results_test set name=? where name=?', 'foo', 'foo1')->affected_rows, 0, 'right affected rows';
+is $db->query('update results_test set name=? where name=?', 'foo', 'foo')->affected_rows, 0, 'right affected rows';
+is $db->query('update results_test set id=1 where id=1')->affected_rows, 0, 'right affected rows';
+
+$res = $db->query("select 1 + '4a'");
+is_deeply $res->array, [ 5 ];
+is $res->warnings_count, 1, 'warnings';
+
+$res = $db->query('show warnings');
+like $res->hashes->[0]->{Message}, qr/Truncated/, 'warning message';
+
+$db->disconnect;
+
+$mysql->options->{mysql_client_found_rows} = 1;
+$db = $mysql->db;
+
+is $db->query('update results_test set name=? where name=?', 'foo', 'foo1')->affected_rows, 0, 'right affected rows';
+is $db->query('update results_test set name=? where name=?', 'foo', 'foo')->affected_rows, 1, 'right affected rows';
+is $db->query('update results_test set id=1 where id=1')->affected_rows, 1, 'right affected rows';
+
+$db->query('drop table results_test');
+
+my $err;
+Mojo::IOLoop->delay(
+	sub {
+		my $delay = shift;
+		$db->query('select name from results_test', $delay->begin);
+	},
+	sub {
+		my $delay = shift;
+		$err = shift;
+		$res = shift;
+	}
+)->wait;
+like $err, qr/results_test/, 'has error';
+is $err, $res->errstr, 'same error';
+is length($res->state), 5, 'has state';
+
+done_testing;

--- a/t/utf8.t
+++ b/t/utf8.t
@@ -9,18 +9,18 @@ plan skip_all => 'set TEST_ONLINE to enable this test' unless $ENV{TEST_ONLINE};
 use Mojo::mysql;
 
 my $mysql = Mojo::mysql->new($ENV{TEST_ONLINE});
-my $db    = $mysql->db->do(
+my $db    = $mysql->db;
+$db->query(
   'create table if not exists results_test (
      id serial primary key,
      name varchar(255) charset utf8
    )'
 );
-$db->do('truncate table results_test');
+$db->query('truncate table results_test');
 $db->query('insert into results_test (name) values (?)', $_) for qw(☺ ☻);
 
 # Result methods
-my $rows = $db->dbh->{mysql_use_result} ? 0 : 2;
-is_deeply $db->query('select * from results_test')->rows, $rows, 'two rows';
+is_deeply $db->query('select * from results_test')->rows, 2, 'two rows';
 is_deeply $db->query('select * from results_test')->columns, ['id', 'name'], 'right structure';
 is_deeply $db->query('select * from results_test')->array,   [1,    '☺'],  'right structure';
 is_deeply [$db->query('select * from results_test')->arrays->each], [[1, '☺'], [2, '☻']], 'right structure';
@@ -29,6 +29,6 @@ is_deeply [$db->query('select * from results_test')->hashes->each],
   [{id => 1, name => '☺'}, {id => 2, name => '☻'}], 'right structure';
 is $mysql->db->query('select * from results_test')->text, "1  ☺\n2  ☻\n", 'right text';
 
-$db->do('drop table results_test');
+$db->query('drop table results_test');
 
 done_testing();


### PR DESCRIPTION
Deprecate ::Database::do in favour of query as in Mojo::Pg
Some new methods in ::Result eliminating need to access 'sth'
Bugfix in ::Migrations with trailing whitespace after last ";"
