### PR TITLE
migrations parser

### DIFF
--- a/lib/Mojo/mysql/Migrations.pm
+++ b/lib/Mojo/mysql/Migrations.pm
@@ -23,13 +23,15 @@ sub from_file { shift->from_string(decode 'UTF-8', slurp pop) }
 
 sub from_string {
   my ($self, $sql) = @_;
+  return $self unless defined $sql;
+
   my ($version, $way);
   my ($new, $last, $delimiter) = (1, '', ';');
   my $migrations = $self->{migrations} = {up => {}, down => {}};
 
   _utf8_off $sql;
 
-  while ($sql) {
+  while (length($sql) > 0) {
     my $token;
 
     if ($sql =~ /^$delimiter/x) {

--- a/lib/Mojo/mysql/Migrations.pm
+++ b/lib/Mojo/mysql/Migrations.pm
@@ -4,6 +4,7 @@ use Mojo::Base -base;
 use Carp 'croak';
 use Mojo::Loader 'data_section';
 use Mojo::Util qw(decode slurp);
+use Encode '_utf8_off';
 
 use constant DEBUG => $ENV{MOJO_MIGRATIONS_DEBUG} || 0;
 
@@ -25,6 +26,8 @@ sub from_string {
   my ($version, $way);
   my ($new, $last, $delimiter) = (1, '', ';');
   my $migrations = $self->{migrations} = {up => {}, down => {}};
+
+  _utf8_off $sql;
 
   while ($sql) {
     my $token;

--- a/lib/Mojo/mysql/Migrations.pm
+++ b/lib/Mojo/mysql/Migrations.pm
@@ -95,24 +95,21 @@ sub migrate {
   my $db = $self->mysql->db;
   return $self if $self->_active($db, 1) == $target;
 
-  # Lock migrations table and check version again
+  # Check version again
   my $tx = $db->begin;
   return $self if (my $active = $self->_active($db, 1)) == $target;
 
   # Up
   my @sql;
   if ($active < $target) {
-    my @up = grep { $_ <= $target && $_ > $active } sort keys %$up;
-    foreach (@up) {
-      push @sql, @{$up->{$_}};
+    foreach (sort keys %$up) {
+      push @sql, @{$up->{$_}} if $_ <= $target && $_ > $active;
     }
   }
-
   # Down
   else {
-    my @down = grep { $_ > $target && $_ <= $active } reverse sort keys %$down;
-    foreach (@down) {
-      push @sql, @{$down->{$_}};
+    foreach (reverse sort keys %$down) {
+      push @sql, @{$down->{$_}} if $_ > $target && $_ <= $active;
     }
   }
 

--- a/lib/Mojo/mysql/Migrations.pm
+++ b/lib/Mojo/mysql/Migrations.pm
@@ -35,37 +35,21 @@ sub from_string {
     elsif ($sql =~ /^delimiter\s*(\S+)/ip) {
       ($new, $token, $delimiter) = (1, ${^MATCH}, $1);
     }
-    elsif ($sql =~ /^(\s+)/) {
-      # whitespace
+    elsif ($sql =~ /^(\s+)/ # whitespace
+      or $sql =~ /^(\w+)/   # general name
+      )
+    {
       $token = $1;
     }
-    elsif ($sql =~ /^--.*(?:\n|\z)/p) {
-      # double-dash comment
+    elsif ($sql =~ /^--.*(?:\n|\z)/p                        # double-dash comment
+      or $sql =~ /^\#.*(?:\n|\z)/p                          # hash comment
+      or $sql =~ /^\/\*(?:[^\*]|\*[^\/])*(?:\*\/|\*\z|\z)/p # C-style comment
+      or $sql =~ /^'(?:[^'\\]*|\\(?:.|\n)|'')*(?:'|\z)/p    # single-quoted literal text
+      or $sql =~ /^"(?:[^"\\]*|\\(?:.|\n)|"")*(?:"|\z)/p    # double-quoted literal text
+      or $sql =~ /^`(?:[^`]*|``)*(?:`|\z)/p                 # schema-quoted literal text
+      )
+    {
       $token = ${^MATCH};
-    }
-    elsif ($sql =~ /^\#.*(?:\n|\z)/p) {
-      # hash comment
-      $token = ${^MATCH};
-    }
-    elsif ($sql =~ /^\/\*(?:[^\*]|\*[^\/])*(?:\*\/|\*\z|\z)/p) {
-      # C-style comment
-      $token = ${^MATCH};
-    }
-    elsif ($sql =~ /^'(?:[^'\\]*|\\(?:.|\n)|'')*(?:'|\z)/p) {
-      # single-quoted literal text
-      $token = ${^MATCH};
-    }
-    elsif ($sql =~ /^"(?:[^"\\]*|\\(?:.|\n)|"")*(?:"|\z)/p) {
-      # double-quoted literal text
-      $token = ${^MATCH};     
-    }
-    elsif ($sql =~ /^`(?:[^`]*|``)*(?:`|\z)/p) {
-      # schema-quoted literal text
-      $token = ${^MATCH};     
-    }
-    elsif ($sql =~ /^(\w+)/) {
-      # general name
-      $token = $1;
     }
     else {
       $token = substr($sql, 0, 1);

--- a/lib/Mojo/mysql/Migrations.pm
+++ b/lib/Mojo/mysql/Migrations.pm
@@ -35,11 +35,11 @@ sub from_string {
     if ($sql =~ /^$delimiter/x) {
       ($new, $token) = (1, $delimiter);
     }
-    elsif ($sql =~ /^delimiter\s*(\S+)/ip) {
+    elsif ($sql =~ /^delimiter\s+(\S+)\s*(?:\n|\z)/ip) {
       ($new, $token, $delimiter) = (1, ${^MATCH}, $1);
     }
-    elsif ($sql =~ /^(\s+)/s  # whitespace
-      or $sql =~ /^(\w+)/     # general name
+    elsif ($sql =~ /^(\s+)/s                                # whitespace
+      or $sql =~ /^(\w+)/                                   # general name
       )
     {
       $token = $1;
@@ -66,7 +66,7 @@ sub from_string {
       push @{$migrations->{$way}{$version} //= []}, $last
         if $version and $last !~ /^\s*$/s;
       ($version, $way) = ($new_version, $new_way);
-      ($new, $last) = (0, '');
+      ($new, $last, $delimiter) = (0, '', ';');
     }
 
     if ($new) {
@@ -174,8 +174,15 @@ C<-- VERSION UP/DOWN>.
   -- 1 up
   create table messages (message text);
   insert into messages values ('I ♥ Mojolicious!');
+  delimiter //
+  create procedure mojo_test()
+  begin
+    select text from messages;
+  end
+  //
   -- 1 down
   drop table messages;
+  drop procedure mojo_test;
 
   -- 2 up (...you can comment freely here...)
   create table stuff (whatever int);

--- a/lib/Mojo/mysql/Migrations.pm
+++ b/lib/Mojo/mysql/Migrations.pm
@@ -35,8 +35,8 @@ sub from_string {
     elsif ($sql =~ /^delimiter\s*(\S+)/ip) {
       ($new, $token, $delimiter) = (1, ${^MATCH}, $1);
     }
-    elsif ($sql =~ /^(\s+)/ # whitespace
-      or $sql =~ /^(\w+)/   # general name
+    elsif ($sql =~ /^(\s+)/s  # whitespace
+      or $sql =~ /^(\w+)/     # general name
       )
     {
       $token = $1;

--- a/t/mysql_lite_app.t
+++ b/t/mysql_lite_app.t
@@ -19,7 +19,7 @@ get '/blocking' => sub {
   my $c  = shift;
   my $db = $c->mysql->db;
   $c->res->headers->header('X-PID' => $db->pid);
-  $c->render(text => $db->query('select * from app_test')->hash->{stuff});
+  $c->render(text => $db->query('call mojo_app_test()')->hash->{stuff});
 };
 
 get '/non-blocking' => sub {
@@ -57,9 +57,17 @@ __DATA__
 @@ app_test
 -- 1 up
 create table if not exists app_test (stuff text);
+delimiter //
+create procedure mojo_app_test()
+  deterministic reads sql data
+begin
+  select * from app_test;
+end
+//
 
 -- 2 up
 insert into app_test values ('I ♥ Mojolicious!');
 
 -- 1 down
 drop table app_test;
+drop procedure mojo_app_test;


### PR DESCRIPTION
- support for delimiter
- correct split of sql statements
- ';' or other defined delimiter in quotes and comments
- possible to define stored procedures and triggers in migration scripts
