### PR TITLE
Remove discouraging text about migrations

### DIFF
--- a/lib/Mojo/mysql.pm
+++ b/lib/Mojo/mysql.pm
@@ -249,7 +249,7 @@ easily.
 
 MySQL does not support nested transactions and DDL transactions.
 DDL statements cause implicit C<COMMIT>. C<ROLLBACK> will be called if
-any step of migration script fails, but not everything can be reverted.
+any step of migration script fails, but only DML statements can be reverted.
 
 This means database can be left in unknown state if migration script fails.
 Use this feature with caution and remember to always backup your database.

--- a/lib/Mojo/mysql.pm
+++ b/lib/Mojo/mysql.pm
@@ -253,7 +253,7 @@ any step of migration script fails, but only DML statements after the
 last implicit or explicit C<COMMIT> can be reverted.
 Not all MySQL storage engines (like C<MYISAM>) support transactions.
 
-This means database can be left in unknown state if migration script fails.
+This means database will most likely be left in unknown state if migration script fails.
 Use this feature with caution and remember to always backup your database.
 
 =head2 options

--- a/lib/Mojo/mysql.pm
+++ b/lib/Mojo/mysql.pm
@@ -249,7 +249,10 @@ easily.
 
 MySQL does not support nested transactions and DDL transactions.
 DDL statements cause implicit C<COMMIT>. C<ROLLBACK> will be called if
-migration script fails, but not everything will be reverted.
+any step of migration script fails, but not everything can be reverted.
+
+This means database can be left in unknown state if migration script fails.
+Use this feature with caution and remember to always backup your database.
 
 =head2 options
 

--- a/lib/Mojo/mysql.pm
+++ b/lib/Mojo/mysql.pm
@@ -238,10 +238,6 @@ C<5>.
 
 =head2 migrations
 
-MySQL does not support nested transactions and DDL transactions.
-DDL statements cause implicit C<COMMIT>.
-B<Therefore, migrations should be used with extreme caution. Backup your database. You've been warned.> 
-
   my $migrations = $mysql->migrations;
   $mysql         = $mysql->migrations(Mojo::mysql::Migrations->new);
 
@@ -250,6 +246,10 @@ easily.
 
   # Load migrations from file and migrate to latest version
   $mysql->migrations->from_file('/Users/sri/migrations.sql')->migrate;
+
+MySQL does not support nested transactions and DDL transactions.
+DDL statements cause implicit C<COMMIT>. C<ROLLBACK> will be called if
+migration script fails, but not everything will be reverted.
 
 =head2 options
 

--- a/lib/Mojo/mysql.pm
+++ b/lib/Mojo/mysql.pm
@@ -249,7 +249,9 @@ easily.
 
 MySQL does not support nested transactions and DDL transactions.
 DDL statements cause implicit C<COMMIT>. C<ROLLBACK> will be called if
-any step of migration script fails, but only DML statements can be reverted.
+any step of migration script fails, but only DML statements after the
+last implicit or explicit C<COMMIT> can be reverted.
+Not all MySQL storage engines (like C<MYISAM>) support transactions.
 
 This means database can be left in unknown state if migration script fails.
 Use this feature with caution and remember to always backup your database.


### PR DESCRIPTION
Migrations are really nice feature.
The current POD looks like they are something very dangerous.
It's better to explain possible unexpected behaviour of the MySQL engine.
