### PR TITLE
bugfix for $mysql->migration->latest version

### DIFF
--- a/lib/Mojo/mysql/Migrations.pm
+++ b/lib/Mojo/mysql/Migrations.pm
@@ -86,7 +86,7 @@ sub from_string {
   return $self;
 }
 
-sub latest { (sort keys %{shift->{migrations}{up}})[-1] || 0 }
+sub latest { (sort { $a <=> $b } keys %{shift->{migrations}{up}})[-1] || 0 }
 
 sub migrate {
   my ($self, $target) = @_;

--- a/t/migrations.t
+++ b/t/migrations.t
@@ -34,6 +34,7 @@ is $mysql->migrations->from_data->latest, 0, 'latest version is 0';
 is $mysql->migrations->from_data(__PACKAGE__)->latest, 0, 'latest version is 0';
 is $mysql->migrations->name('test1')->from_data->latest, 7, 'latest version is 7';
 is $mysql->migrations->name('test2')->from_data->latest, 2, 'latest version is 2';
+is $mysql->migrations->name('test3')->from_data->latest, 12, 'latest version is 12';
 is $mysql->migrations->name('migrations')->from_data(__PACKAGE__, 'test1')
   ->latest, 7, 'latest version is 7';
 is $mysql->migrations->name('test2')->from_data(__PACKAGE__)->latest, 2,
@@ -115,3 +116,42 @@ create table migration_test_four (test int));
 @@ test2
 -- 2 up
 create table migration_test_five (test int);
+
+@@ test3
+-- 1 up
+CREATE TABLE "MyTable" (
+    col1 text
+);
+
+-- 2 up
+ALTER TABLE "MyTable" ADD COLUMN col2 text;
+
+-- 3 up
+ALTER TABLE "MyTable" ADD COLUMN col3 text;
+
+-- 4 up
+ALTER TABLE "MyTable" ADD COLUMN col4 text;
+
+-- 5 up
+ALTER TABLE "MyTable" ADD COLUMN col5 text;
+
+-- 6 up
+ALTER TABLE "MyTable" ADD COLUMN col6 text;
+
+-- 7 up
+ALTER TABLE "MyTable" ADD COLUMN col7 text;
+
+-- 8 up
+ALTER TABLE "MyTable" ADD COLUMN col8 text;
+
+-- 9 up
+ALTER TABLE "MyTable" ADD COLUMN col9 text;
+
+-- 10 up
+ALTER TABLE "MyTable" ADD COLUMN col10 text;
+
+-- 11 up
+ALTER TABLE "MyTable" ADD COLUMN col11 text;
+
+-- 12 up
+ALTER TABLE "MyTable" ADD COLUMN col12 text;


### PR DESCRIPTION
# _Same bug as Mojo::Pg with similar bugfix_
# BUG: I have migrations up from 1 to 11. Mojo::Pg stopped getting my migrations at 9. The problem is at how the version sort is performed (It is not sorting numerically.)
# Current sort: 1,10,11,2,3,4,5,6,7,8,9
# Correct sort: 1,2,3,4,5,6,7,8,9,10,11 with { $a <=> $b }
# 
# to reproduce:
#1. Create migrations string with 12 up
#2. Instanciate mojo mysql and load migrations string.
#3. Check the latest which should be 12. But returns 9.
# This is the proof that Mojo::Mysql::Migrations is not numerically sorting

use lib './lib';
use Mojo::Mysql;
my $mysql = Mojo::Mysql->new;
my $migration = <<MIGRATIONS;

-- 1 up
CREATE TABLE "MyTable" (
    col1 text
);

-- 2 up
ALTER TABLE "MyTable" ADD COLUMN col2 text;

-- 3 up
ALTER TABLE "MyTable" ADD COLUMN col3 text;

-- 4 up
ALTER TABLE "MyTable" ADD COLUMN col4 text;

-- 5 up
ALTER TABLE "MyTable" ADD COLUMN col5 text;

-- 6 up
ALTER TABLE "MyTable" ADD COLUMN col6 text;

-- 7 up
ALTER TABLE "MyTable" ADD COLUMN col7 text;

-- 8 up
ALTER TABLE "MyTable" ADD COLUMN col8 text;

-- 9 up
ALTER TABLE "MyTable" ADD COLUMN col9 text;

-- 10 up
ALTER TABLE "MyTable" ADD COLUMN col10 text;

-- 11 up
ALTER TABLE "MyTable" ADD COLUMN col11 text;

-- 12 up
ALTER TABLE "MyTable" ADD COLUMN col12 text;

MIGRATIONS

my $latest = $mysql->migrations->from_string( $migration )->latest;
warn "WRONG  : $latest \* \* \* should be 12";

*Mojo::Mysql::Migrations::latest = sub {
    (sort { $a <=> $b } keys %{shift->{migrations}{up}})[-1] || 0
};

my $latest_correct = $mysql->migrations->from_string( $migration )->latest;
warn "CORRECT: $latest_correct";
