### PR TITLE
PubSub for MySQL

### DIFF
--- a/examples/chat.pl
+++ b/examples/chat.pl
@@ -1,0 +1,33 @@
+use Mojolicious::Lite;
+use Mojo::mysql;
+
+helper mysql => sub { state $mysql = Mojo::mysql->new('mysql://oss:prasw0RD@192.168.2.14/oss') };
+
+get '/' => 'chat';
+
+websocket '/channel' => sub {
+  my $c = shift;
+
+  $c->inactivity_timeout(3600);
+
+  # Forward messages from the browser to PostgreSQL
+  $c->on(message => sub { shift->mysql->pubsub->notify(mojochat => shift) });
+
+  # Forward messages from PostgreSQL to the browser
+  my $cb = $c->mysql->pubsub->listen(mojochat => sub { $c->send(pop) });
+  $c->on(finish => sub { shift->mysql->pubsub->unlisten(mojochat => $cb) });
+};
+
+app->start;
+__DATA__
+
+@@ chat.html.ep
+<form onsubmit="sendChat(this.children[0]); return false"><input></form>
+<div id="log"></div>
+<script>
+  var ws  = new WebSocket('<%= url_for('channel')->to_abs %>');
+  ws.onmessage = function (e) {
+    document.getElementById('log').innerHTML += '<p>' + e.data + '</p>';
+  };
+  function sendChat(input) { ws.send(input.value); input.value = '' }
+</script>

--- a/examples/chat.pl
+++ b/examples/chat.pl
@@ -10,10 +10,10 @@ websocket '/channel' => sub {
 
   $c->inactivity_timeout(3600);
 
-  # Forward messages from the browser to PostgreSQL
+  # Forward messages from the browser to MySQL
   $c->on(message => sub { shift->mysql->pubsub->notify(mojochat => shift) });
 
-  # Forward messages from PostgreSQL to the browser
+  # Forward messages from MySQL to the browser
   my $cb = $c->mysql->pubsub->listen(mojochat => sub { $c->send(pop) });
   $c->on(finish => sub { shift->mysql->pubsub->unlisten(mojochat => $cb) });
 };

--- a/examples/chat.pl
+++ b/examples/chat.pl
@@ -1,7 +1,7 @@
 use Mojolicious::Lite;
 use Mojo::mysql;
 
-helper mysql => sub { state $mysql = Mojo::mysql->new('mysql://oss:prasw0RD@192.168.2.14/oss') };
+helper mysql => sub { state $mysql = Mojo::mysql->new('mysql://mysql@/test') };
 
 get '/' => 'chat';
 

--- a/lib/Mojo/mysql.pm
+++ b/lib/Mojo/mysql.pm
@@ -158,7 +158,19 @@ Mojo::mysql - Mojolicious and Async MySQL
     }
   )->wait;
 
+  # Send and receive notifications non-blocking
+  $mysql->pubsub->listen(foo => sub {
+    my ($pubsub, $payload) = @_;
+    say "foo: $payload";
+    $pubsub->notify(bar => $payload);
+  });
+  $mysql->pubsub->listen(bar => sub {
+    my ($pubsub, $payload) = @_;
+    say "bar: $payload";
+  });
+  $mysql->pubsub->notify(foo => 'MySQL rocks!');
   Mojo::IOLoop->start unless Mojo::IOLoop->is_running;
+
 
 =head1 DESCRIPTION
 
@@ -285,6 +297,23 @@ C<RaiseError> is enabled for blocking and disabled in event loop for non-blockin
   $mysql       = $mysql->password('s3cret');
 
 Database password, defaults to an empty string.
+
+=head2 pubsub
+
+  my $pubsub = $mysql->pubsub;
+  $mysql     = $mysql->pubsub(Mojo::mysql::PubSub->new);
+
+L<Mojo::mysql::PubSub> object you can use to send and receive notifications very
+efficiently, by sharing a single database connection with many consumers.
+
+  # Subscribe to a channel
+  $mysql->pubsub->listen(news => sub {
+    my ($pubsub, $payload) = @_;
+    say "Received: $payload";
+  });
+
+  # Notify a channel
+  $mysql->pubsub->notify(news => 'MySQL rocks!');
 
 =head2 username
 

--- a/lib/Mojo/mysql.pm
+++ b/lib/Mojo/mysql.pm
@@ -5,6 +5,7 @@ use Carp 'croak';
 use DBI;
 use Mojo::mysql::Database;
 use Mojo::mysql::Migrations;
+use Mojo::mysql::PubSub;
 use Mojo::URL;
 use Scalar::Util 'weaken';
 
@@ -25,6 +26,12 @@ has options => sub {
   }
 };
 has [qw(password username)] => '';
+has pubsub => sub {
+  my $pubsub = Mojo::mysql::PubSub->new(mysql => shift);
+  weaken $pubsub->{mysql};
+  return $pubsub;
+};
+
 
 our $VERSION = '0.11';
 

--- a/lib/Mojo/mysql.pm
+++ b/lib/Mojo/mysql.pm
@@ -169,8 +169,8 @@ Mojo::mysql - Mojolicious and Async MySQL
     say "bar: $payload";
   });
   $mysql->pubsub->notify(foo => 'MySQL rocks!');
-  Mojo::IOLoop->start unless Mojo::IOLoop->is_running;
 
+  Mojo::IOLoop->start unless Mojo::IOLoop->is_running;
 
 =head1 DESCRIPTION
 
@@ -376,6 +376,8 @@ This is the class hierarchy of the L<Mojo::mysql> distribution.
 =item * L<Mojo::mysql::Database>
 
 =item * L<Mojo::mysql::Migrations>
+
+=item * L<Mojo::mysql::PubSub>
 
 =item * L<Mojo::mysql::Results>
 

--- a/lib/Mojo/mysql/PubSub.pm
+++ b/lib/Mojo/mysql/PubSub.pm
@@ -160,6 +160,15 @@ C<connection_id> and subscribed channels in stored in C<mojo_pubsub_subscribe> t
 Inserting new row in C<mojo_pubsub_notify> table triggers C<KILL QUERY> for
 all connections waiting for notification.
 
+C<PROCESS> privilege is needed for MySQL user to see other users processes.
+C<SUPER> privilege is needed to be able to execute C<KILL QUERY> for statements
+started by other users. 
+C<SUPERT> privilege may be needed to be able to define trigger.
+
+If your applications use this module using different MySQL users it is important
+the migration script to be executed by user having C<SUPER> privilege on the database.
+
+
 =head1 EVENTS
 
 L<Mojo::mysql::PubSub> inherits all events from L<Mojo::EventEmitter> and can

--- a/lib/Mojo/mysql/PubSub.pm
+++ b/lib/Mojo/mysql/PubSub.pm
@@ -233,11 +233,12 @@ L<Mojo::mysql>, L<Mojolicious::Guides>, L<http://mojolicio.us>.
 __DATA__
 
 @@ pubsub
--- 1 up
+-- 1 down
 drop table if exists mojo_pubsub_subscribe;
 drop table if exists mojo_pubsub_notify;
 drop trigger if exists mojo_pubsub_notify_kill;
 
+-- 1 up
 create table mojo_pubsub_subscribe(
   id integer auto_increment primary key,
   pid integer not null,
@@ -250,7 +251,7 @@ create table mojo_pubsub_subscribe(
 create table mojo_pubsub_notify(
   id integer auto_increment primary key,
   channel varchar(64) not null,
-  payload varchar(256),
+  payload text,
   ts timestamp not null default current_timestamp,
   key channel_idx(channel),
   key ts_idx(ts)

--- a/lib/Mojo/mysql/PubSub.pm
+++ b/lib/Mojo/mysql/PubSub.pm
@@ -163,7 +163,7 @@ all connections waiting for notification.
 C<PROCESS> privilege is needed for MySQL user to see other users processes.
 C<SUPER> privilege is needed to be able to execute C<KILL QUERY> for statements
 started by other users. 
-C<SUPERT> privilege may be needed to be able to define trigger.
+C<SUPER> privilege may be needed to be able to define trigger.
 
 If your applications use this module using different MySQL users it is important
 the migration script to be executed by user having C<SUPER> privilege on the database.

--- a/lib/Mojo/mysql/PubSub.pm
+++ b/lib/Mojo/mysql/PubSub.pm
@@ -7,6 +7,12 @@ use constant DEBUG => $ENV{MOJO_PUBSUB_DEBUG} || 0;
 
 has 'mysql';
 
+sub DESTROY {
+  my $self = shift;
+  return unless $self->{db} and $self->mysql;
+  $self->mysql->db->query('delete from mojo_pubsub_subscribe where pid = ?', $self->_subscriber_pid);
+}
+
 sub listen {
   my ($self, $channel, $cb) = @_;
   my $pid = $self->_subscriber_pid;

--- a/lib/Mojo/mysql/PubSub.pm
+++ b/lib/Mojo/mysql/PubSub.pm
@@ -251,6 +251,9 @@ drop table mojo_pubsub_subscribe;
 drop table mojo_pubsub_notify;
 
 -- 1 up
+drop table if exists mojo_pubsub_subscribe;
+drop table if exists mojo_pubsub_notify;
+
 create table mojo_pubsub_subscribe(
   id integer auto_increment primary key,
   pid integer not null,

--- a/lib/Mojo/mysql/PubSub.pm
+++ b/lib/Mojo/mysql/PubSub.pm
@@ -1,0 +1,160 @@
+package Mojo::mysql::PubSub;
+use Mojo::Base 'Mojo::EventEmitter';
+
+use Scalar::Util 'weaken';
+
+has 'mysql';
+
+sub listen {
+  my ($self, $name, $cb) = @_;
+  my $sleeping = $self->_db;
+  my $sql = @{$self->{chans}{$name} ||= []} ?
+    'update mojo_pubsub_subscribe set ts = current_timestamp where pid = ? and channel = ?' :
+    'insert into mojo_pubsub_subscribe(pid, channel) values (?, ?)';
+  $self->mysql->db->query($sql, $sleeping->pid, $name);
+  push @{$self->{chans}{$name}}, $cb;
+  return $cb;
+}
+
+sub notify {
+  my ($self, $name, $payload) = @_;
+  $self->_db;
+  $self->mysql->db->query(
+    'insert into mojo_pubsub_notify(channel, message) values (?, ?)', $name, $payload);
+  return $self;
+}
+
+sub unlisten {
+  my ($self, $name, $cb) = @_;
+  my $chan = $self->{chans}{$name};
+  @$chan = grep { $cb ne $_ } @$chan;
+  return $self if @$chan;
+  my $sleeping = $self->_db;
+  $self->mysql->db->query(
+    'delete from mojo_pubsub_subscribe where pid = ? and channel = ?',
+    $sleeping->pid, $name);
+  delete $self->{chans}{$name};
+  return $self;
+}
+
+sub _db {
+  my $self = shift;
+
+  # Fork-safety
+  delete @$self{qw(chans pid)} and $self->{db} and $self->{db}->disconnect
+    unless ($self->{pid} //= $$) eq $$;
+
+  return $self->{db} if $self->{db};
+
+  $self->mysql->migrations->from_data(__PACKAGE__, 'pubsub')->migrate;
+
+  my $db = $self->{db} = $self->mysql->db;
+
+  # id of the last message in table
+  if (!defined $self->{last_id}) {
+    my $array = $db->query(
+      'select id from mojo_pubsub_notify order by id desc limit 1')->array;
+    $self->{last_id} = defined $array ? $array->[0] : 0;
+  }
+
+  # cleanup old subscriptions and notifications
+  $db->query(
+    'delete from mojo_pubsub_notify where ts < date_add(current_timestamp, interval -10 minute)');
+  $db->query(
+    'delete from mojo_pubsub_subscribe where ts < date_add(current_timestamp, interval -1 hour)');
+
+  # re-subscribe
+  $db->query(
+    'delete from mojo_pubsub_subscribe where pid = ?', $db->pid);
+  $db->query(
+    'insert into mojo_pubsub_subscribe(pid, channel) values (?, ?)', $db->pid, $_)
+    for keys %{$self->{chans}};
+
+  weaken $db->{mysql};
+  weaken $self;
+
+  my $cb;
+  $cb = sub {
+    $db->query(
+      'select id, channel, message from mojo_pubsub_notify where id > ?',
+      $self->{last_id})->hashes->each(
+      sub {
+        my ($id, $channel, $payload) = ($_->{id}, $_->{channel}, $_->{message});
+        $self->{last_id} = $id;
+        return unless exists $self->{chans}{$channel};
+        for my $cb (@{$self->{chans}{$channel}}) { $self->$cb($payload) }
+      }
+    );
+    $db->query('update mojo_pubsub_subscribe set ts = current_timestamp where pid = ?', $db->pid);
+    $db->query('select sleep(600)', $cb);
+  };
+  $db->query('select sleep(600)', $cb);
+
+  $self->emit(reconnect => $db);
+
+  return $db;
+}
+
+1;
+
+__DATA__
+
+@@ pubsub
+-- 1 up
+drop table if exists mojo_pubsub_subscribe;
+drop table if exists mojo_pubsub_notify;
+drop trigger if exists mojo_pubsub_notify_kill;
+
+create table mojo_pubsub_subscribe(
+  id integer auto_increment primary key,
+  pid integer not null,
+  channel varchar(64) not null,
+  ts timestamp not null default current_timestamp,
+  unique key subs_idx(pid, channel),
+  key ts_idx(ts)
+);
+
+create table mojo_pubsub_notify(
+  id integer auto_increment primary key,
+  channel varchar(64) not null,
+  message varchar(256),
+  ts timestamp not null default current_timestamp,
+  key channel_idx(channel),
+  key ts_idx(ts)
+);
+
+delimiter //
+
+create trigger mojo_pubsub_notify_kill after insert on mojo_pubsub_notify
+for each row
+begin
+  declare done boolean default false;
+  declare t_pid integer;
+
+  declare subs_c cursor for
+  select pid from mojo_pubsub_subscribe where channel = NEW.channel;
+
+  declare continue handler for not found set done = true;
+
+  open subs_c;
+
+  repeat
+    fetch subs_c into t_pid;
+
+    if not done
+    then
+      if exists (select 1
+        from INFORMATION_SCHEMA.PROCESSLIST
+        where ID = t_pid and STATE = 'User sleep')
+      then 
+        kill query t_pid;
+      end if;
+    end if;
+
+  until done end repeat;
+
+  close subs_c;
+end
+//
+
+delimiter ;

--- a/lib/Mojo/mysql/PubSub.pm
+++ b/lib/Mojo/mysql/PubSub.pm
@@ -97,6 +97,104 @@ sub _db {
 
 1;
 
+=encoding utf8
+
+=head1 NAME
+
+Mojo::mysql::PubSub - Publish/Subscribe
+
+=head1 SYNOPSIS
+
+  use Mojo::mysql::PubSub;
+
+  my $pubsub = Mojo::mysql::PubSub->new(mysql => $mysql);
+  my $cb = $pubsub->listen(foo => sub {
+    my ($pubsub, $payload) = @_;
+    say "Received: $payload";
+  });
+  $pubsub->notify(foo => 'bar');
+  $pubsub->unlisten(foo => $cb);
+
+=head1 DESCRIPTION
+
+L<Mojo::mysql::PubSub> is implementation of the publish/subscribe
+pattern used by L<Mojo::mysql>.
+
+Although MySQL does not have C<SUBSCRIBE/NOTIFY> like PostgreSQL and other RDBMs,
+this module implements similar feature.
+
+Single Database connection waits for notification by executing C<SLEEP> on server.
+C<connection_id> and subscribed channels in stored in C<mojo_pubsub_subscribe> table.
+Inserting new row in C<mojo_pubsub_notify> table triggers C<KILL QUERY> for
+all connections waiting for notification.
+
+=head1 EVENTS
+
+L<Mojo::mysql::PubSub> inherits all events from L<Mojo::EventEmitter> and can
+emit the following new ones.
+
+=head2 reconnect
+
+  $pubsub->on(reconnect => sub {
+    my ($pubsub, $db) = @_;
+    ...
+  });
+
+Emitted after switching to a new database connection for sending and receiving
+notifications.
+
+=head1 ATTRIBUTES
+
+L<Mojo::mysql::PubSub> implements the following attributes.
+
+=head2 mysql
+
+  my $mysql = $pubsub->mysql;
+  $pubsub   = $pubsub->mysql(Mojo::mysql->new);
+
+L<Mojo::mysql> object this publish/subscribe container belongs to.
+
+=head1 METHODS
+
+L<Mojo::mysql::PubSub> inherits all methods from L<Mojo::EventEmitter> and
+implements the following new ones.
+
+=head2 listen
+
+  my $cb = $pubsub->listen(foo => sub {...});
+
+Subscribe to a channel, there is no limit on how many subscribers a channel can
+have.
+
+  # Subscribe to the same channel twice
+  $pubsub->listen(foo => sub {
+    my ($pubsub, $payload) = @_;
+    say "One: $payload";
+  });
+  $pubsub->listen(foo => sub {
+    my ($pubsub, $payload) = @_;
+    say "Two: $payload";
+  });
+
+=head2 notify
+
+  $pubsub = $pubsub->notify('foo');
+  $pubsub = $pubsub->notify(foo => 'bar');
+
+Notify a channel.
+
+=head2 unlisten
+
+  $pubsub = $pubsub->unlisten(foo => $cb);
+
+Unsubscribe from a channel.
+
+=head1 SEE ALSO
+
+L<Mojo::mysql>, L<Mojolicious::Guides>, L<http://mojolicio.us>.
+
+=cut
+
 __DATA__
 
 @@ pubsub

--- a/t/pubsub.t
+++ b/t/pubsub.t
@@ -1,0 +1,104 @@
+use Mojo::Base -strict;
+
+BEGIN { $ENV{MOJO_REACTOR} = 'Mojo::Reactor::Poll' }
+
+use Test::More;
+
+plan skip_all => 'set TEST_ONLINE to enable this test'
+  unless $ENV{TEST_ONLINE};
+
+use Mojo::IOLoop;
+use Mojo::mysql;
+
+# Notifications with event loop
+my $mysql = Mojo::mysql->new($ENV{TEST_ONLINE});
+my ($db, @test);
+$mysql->pubsub->on(reconnect => sub { $db = pop });
+$mysql->pubsub->listen(
+  pstest => sub {
+    my ($pubsub, $payload) = @_;
+    push @test, $payload;
+    Mojo::IOLoop->next_tick(sub { $pubsub->notify(pstest => 'stop') });
+    Mojo::IOLoop->stop if $payload eq 'stop';
+  }
+);
+$mysql->pubsub->notify(pstest => 'test');
+Mojo::IOLoop->start;
+is_deeply \@test, ['test', 'stop'], 'right messages';
+
+# Unsubscribe
+$mysql = Mojo::mysql->new($ENV{TEST_ONLINE});
+$db = undef;
+$mysql->pubsub->on(reconnect => sub { $db = pop });
+@test = ();
+my $first  = $mysql->pubsub->listen(pstest => sub { push @test, pop });
+my $second = $mysql->pubsub->listen(pstest => sub { push @test, pop });
+$mysql->pubsub->notify('pstest')->notify(pstest => 'first');
+is_deeply \@test, ['', '', 'first', 'first'], 'right messages';
+$mysql->pubsub->unlisten(pstest => $first)->notify(pstest => 'second');
+is_deeply \@test, ['', '', 'first', 'first', 'second'], 'right messages';
+$mysql->pubsub->unlisten(pstest => $second)->notify(pstest => 'third');
+is_deeply \@test, ['', '', 'first', 'first', 'second'], 'right messages';
+
+# Reconnect while listening
+$mysql = Mojo::mysql->new($ENV{TEST_ONLINE});
+my @dbhs = @test = ();
+$mysql->pubsub->on(reconnect => sub { push @dbhs, pop->dbh });
+$mysql->pubsub->listen(pstest => sub { push @test, pop });
+ok $dbhs[0], 'database handle';
+is_deeply \@test, [], 'no messages';
+{
+  local $dbhs[0]{Warn} = 0;
+  $mysql->pubsub->on(
+    reconnect => sub { shift->notify(pstest => 'works'); Mojo::IOLoop->stop });
+  $mysql->db->query('kill ?', $dbhs[0]{mysql_thread_id});
+  Mojo::IOLoop->start;
+  ok $dbhs[1], 'database handle';
+  isnt $dbhs[0], $dbhs[1], 'different database handles';
+  is_deeply \@test, ['works'], 'right messages';
+};
+
+# Reconnect while not listening
+$mysql = Mojo::mysql->new($ENV{TEST_ONLINE});
+@dbhs = @test = ();
+$mysql->pubsub->on(reconnect => sub { push @dbhs, pop->dbh });
+$mysql->pubsub->notify(pstest => 'fail');
+ok $dbhs[0], 'database handle';
+is_deeply \@test, [], 'no messages';
+{
+  local $dbhs[0]{Warn} = 0;
+  $mysql->pubsub->on(reconnect => sub { Mojo::IOLoop->stop });
+  $mysql->db->query('kill ?', $dbhs[0]{mysql_thread_id});
+  Mojo::IOLoop->start;
+  ok $dbhs[1], 'database handle';
+  isnt $dbhs[0], $dbhs[1], 'different database handles';
+  $mysql->pubsub->listen(pstest => sub { push @test, pop });
+  $mysql->pubsub->notify(pstest => 'works too');
+  is_deeply \@test, ['works too'], 'right messages';
+};
+
+# Fork-safety
+$mysql = Mojo::mysql->new($ENV{TEST_ONLINE});
+@dbhs = @test = ();
+$mysql->pubsub->on(reconnect => sub { push @dbhs, pop->dbh });
+$mysql->pubsub->listen(pstest => sub { push @test, pop });
+ok $dbhs[0], 'database handle';
+ok $dbhs[0]->ping, 'connected';
+$mysql->pubsub->notify(pstest => 'first');
+is_deeply \@test, ['first'], 'right messages';
+{
+  local $$ = -23;
+  $mysql->pubsub->notify(pstest => 'second');
+  ok $dbhs[1], 'database handle';
+  ok $dbhs[1]->ping, 'connected';
+  isnt $dbhs[0], $dbhs[1], 'different database handles';
+  ok !$dbhs[0]->ping, 'not connected';
+  is_deeply \@test, ['first'], 'right messages';
+  $mysql->pubsub->listen(pstest => sub { push @test, pop });
+  $mysql->pubsub->notify(pstest => 'third');
+  ok $dbhs[1]->ping, 'connected';
+  ok !$dbhs[2], 'no database handle';
+  is_deeply \@test, ['first', 'third'], 'right messages';
+};
+
+done_testing();


### PR DESCRIPTION
MySQL does not have LISTEN/NOTIFY mechanism like PostgreSQL.
This implementation assigns single database connection to wait for notification by executing **SLEEP** on sever. Notifying connections wake up listening connections by executing **KILL QUERY**. Notify payload and list of subscribed connections is stored in tables.

Works on MySQL 5.0 and above.
