### PR TITLE
Use prepare_cached from DBI to cache statement handles

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Revision history for perl distribution Mojo-mysql
 
+0.14 Not Released
+ - Use prepare_cached from DBI to cache statement handles
+   https://github.com/kraih/mojo-pg/commit/42e329ef37fe117d43c1c0929a027fb1498e8d03
+
 0.13 2016-01-27T21:05:37+0100
  - Remove deprecrated do() method
  - Add finish() to Mojo::mysql::Results

--- a/lib/Mojo/mysql/Database.pm
+++ b/lib/Mojo/mysql/Database.pm
@@ -43,7 +43,7 @@ sub query {
 
   # Blocking
   unless ($cb) {
-    my $sth = $self->dbh->prepare($query);
+    my $sth = $self->dbh->prepare_cached($query);
     my $rv  = $sth->execute(@_);
     my $res = Mojo::mysql::Results->new(sth => $sth);
     $res->{affected_rows} = defined $rv && $rv >= 0 ? 0 + $rv : undef;
@@ -65,7 +65,7 @@ sub _next {
   return unless my $next = $self->{waiting}[0];
   return if $next->{sth};
 
-  my $sth = $next->{sth} = $self->dbh->prepare($next->{query}, {async => 1});
+  my $sth = $next->{sth} = $self->dbh->prepare_cached($next->{query}, {async => 1});
   $sth->execute(@{$next->{args}});
 
   # keep reference to async handles to prevent being finished on result destroy while whatching fd

--- a/lib/Mojo/mysql/Results.pm
+++ b/lib/Mojo/mysql/Results.pm
@@ -35,6 +35,9 @@ sub err { shift->sth->err }
 sub errstr { shift->sth->errstr }
 
 sub state { shift->sth->state }
+
+sub DESTROY { $_[0]{sth}->finish if $_[0]{sth} }
+
 1;
 
 =encoding utf8

--- a/t/database.t
+++ b/t/database.t
@@ -11,7 +11,7 @@ ok $mysql->db->ping, 'connected';
 
 # Blocking select
 is_deeply $mysql->db->query('select 1 as one, 2 as two, 3 as three')->hash, {one => 1, two => 2, three => 3},
-  'right structure';
+  'blocking right structure';
 
 # Non-blocking select
 my ($fail, $result);
@@ -29,7 +29,7 @@ is $db->backlog, 1, 'one operation waiting';
 Mojo::IOLoop->start;
 is $db->backlog, 0, 'no operations waiting';
 ok !$fail, 'no error' or diag "err=$fail";
-is_deeply $result, {one => 1, two => 2, three => 3}, 'right structure';
+is_deeply $result, {one => 1, two => 2, three => 3}, 'non-blocking right structure';
 
 # Concurrent non-blocking selects
 ($fail, $result) = ();
@@ -37,9 +37,9 @@ Mojo::IOLoop->delay(
   sub {
     my $delay = shift;
     my $db    = $mysql->db;
-    $db->query('select 1 as one' => $delay->begin);
-    $db->query('select 2 as two' => $delay->begin);
-    $db->query('select 2 as two' => $delay->begin);
+    $db->query('select 1 as one'     => $delay->begin);
+    $db->query('select 2 as two'     => $delay->begin);
+    $db->query('select 2+1 as three' => $delay->begin);
   },
   sub {
     my ($delay, $err_one, $one, $err_two, $two, $err_again, $again) = @_;
@@ -48,7 +48,7 @@ Mojo::IOLoop->delay(
   }
 )->wait;
 ok !$fail, 'no error' or diag "err=$fail";
-is_deeply $result, [{one => 1}, {two => 2}, {two => 2}], 'right structure';
+is_deeply $result, [{one => 1}, {two => 2}, {three => 3}], 'concurrent right structure';
 
 # Sequential and Concurrent non-blocking selects
 ($fail, $result) = ();
@@ -61,15 +61,15 @@ Mojo::IOLoop->delay(
     my ($delay, $err, $res) = @_;
     $fail   = $err;
     $result = [$res->hashes->first];
-    $db->query('select 2 as two' => $delay->begin);
-    $db->query('select 2 as two' => $delay->begin);
+    $db->query('select 2 as two'     => $delay->begin);
+    $db->query('select 2+1 as three' => $delay->begin);
   },
   sub {
     my ($delay, $err_two, $two, $err_again, $again) = @_;
     push @$result, $db->query('select 1 as one')->hashes->first;
     $fail ||= $err_two || $err_again;
     push @$result, $two->hashes->first, $again->hashes->first;
-    $db->query('select 3 as three' => $delay->begin);
+    $db->query('select 2+1 as three' => $delay->begin);
   },
   sub {
     my ($delay, $err_three, $three) = @_;
@@ -78,7 +78,24 @@ Mojo::IOLoop->delay(
   }
 )->wait;
 ok !$fail, 'no error' or diag "err=$fail";
-is_deeply $result, [{one => 1}, {one => 1}, {two => 2}, {two => 2}, {three => 3}], 'right structure';
+is_deeply $result, [{one => 1}, {one => 1}, {two => 2}, {three => 3}, {three => 3}], 'right structure';
+
+# Statement cache
+$db = $mysql->db;
+my $sth = $db->query('select 2+1 as three')->sth;
+is $db->query('select 2+1 as three')->sth, $sth, 'same statement handle';
+isnt $db->query('select 4 as four')->sth,  $sth, 'different statement handles';
+is $db->query('select 2+1 as three')->sth, $sth, 'same statement handle';
+undef $db;
+$db = $mysql->db;
+my $results = $db->query('select 2+1 as three');
+is $results->sth, $sth, 'same statement handle';
+isnt $db->query('select 2+1 as three')->sth, $sth, 'different statement handles';
+$sth = $db->query('select 2+1 as three')->sth;
+is $db->query('select 2+1 as three')->sth, $sth, 'same statement handle';
+isnt $db->query('select 5 as five')->sth,  $sth, 'different statement handles';
+isnt $db->query('select 6 as six')->sth,   $sth, 'different statement handles';
+is $db->query('select 2+1 as three')->sth, $sth, 'same statement handle';
 
 # Connection cache
 is $mysql->max_connections, 5, 'right default';


### PR DESCRIPTION
I would like to pull in https://github.com/kraih/mojo-pg/commit/42e329ef37fe117d43c1c0929a027fb1498e8d03 which use prepare_cached() instead of just prepare() to speed up queries.

But database.t seems to hang with the change. Any idea why @harry-bix ?
