### PR TITLE
Update mojo_migrations key type

### DIFF
--- a/lib/Mojo/mysql/Migrations.pm
+++ b/lib/Mojo/mysql/Migrations.pm
@@ -146,7 +146,7 @@ sub _active {
 
   $db->query(
     'create table if not exists mojo_migrations (
-       name    varchar(255) unique not null,
+       name    varbinary(255) unique not null,
        version bigint not null
      )'
   ) if $error;


### PR DESCRIPTION
When creating the `mojo_migrations` table, the creation may fail with the warning `DBD::mysql::st execute failed: Specified key was too long; max key length is 767 bytes`. The reason is, that the key is specified as a `varchar(255)` that, in a utf8 world (that is the default in some databases) may exceed the 767 limit. There seems to be a lot of discussion about this limitation and there is now an option to increase this limit (`innodb_large_prefix`), but I guess, limiting the size of the key field is a reasonable fix. Another possible fix would be to change the encoding of the table, but I've chosen the varbinary-option as the limitation is byte-bound and not character set bound.

I am no database expert - so I may be totally wrong. ;)
Thanks for your great work on this module!
Best,
Akron

My database is:
Ver 15.1 Distrib 10.0.25-MariaDB, for debian-linux-gnu (x86_64) using readline 5.2
