### PR TITLE
Add ability to set types of query parameters

### DIFF
--- a/t/database.t
+++ b/t/database.t
@@ -1,6 +1,7 @@
 BEGIN { $ENV{MOJO_REACTOR} = 'Mojo::Reactor::Poll' }
 use Mojo::Base -strict;
 use Test::More;
+use DBI ':sql_types';
 use Mojo::IOLoop;
 use Mojo::mysql;
 
@@ -93,6 +94,12 @@ $pid = $mysql->db->pid;
 is $mysql->db->pid, $pid, 'same database pid';
 $mysql->db->disconnect;
 isnt $mysql->db->pid, $pid, 'different database pid';
+
+# Binary data
+$db = $mysql->db;
+my $bytes = "\xF0\xF1\xF2\xF3";
+is_deeply $db->query('select binary ? as foo',
+  {type => SQL_BLOB, value => $bytes})->hash, {foo => $bytes}, 'right data';
 
 # Fork safety
 $pid = $mysql->db->pid;


### PR DESCRIPTION
This is required as binary data must be specified as SQL_BLOB in order to not be UTF-8 encoded, while using the fixed mysql_enable_utf8/mb4 feature (in DBD::mysql 4.042 which Mojo::mysql already depends on). I don't have a running mysql server to run the tests locally so please verify that they work.