### PR TITLE
update mysql_enable_utf8 option to mysql_enable_utf8mb4

### DIFF
--- a/lib/Mojo/mysql.pm
+++ b/lib/Mojo/mysql.pm
@@ -20,7 +20,7 @@ has migrations      => sub {
   return $migrations;
 };
 has options => sub {
-  {mysql_enable_utf8 => 1, AutoCommit => 1, AutoInactiveDestroy => 1, PrintError => 0, RaiseError => 1};
+  {mysql_enable_utf8mb4 => 1, AutoCommit => 1, AutoInactiveDestroy => 1, PrintError => 0, RaiseError => 1};
 };
 has [qw(password username)] => '';
 has pubsub => sub {
@@ -327,7 +327,7 @@ Use this feature with caution and remember to always backup your database.
   my $options = $mysql->options;
   $mysql      = $mysql->options({mysql_use_result => 1});
 
-Options for database handles, defaults to activating C<mysql_enable_utf8>, C<AutoCommit>,
+Options for database handles, defaults to activating C<mysql_enable_utf8mb4>, C<AutoCommit>,
 C<AutoInactiveDestroy> as well as C<RaiseError> and deactivating C<PrintError>.
 Note that C<AutoCommit> and C<RaiseError> are considered mandatory, so
 deactivating them would be very dangerous.

--- a/t/connection.t
+++ b/t/connection.t
@@ -7,7 +7,7 @@ my $mysql = Mojo::mysql->new;
 is $mysql->dsn,      'dbi:mysql:dbname=test', 'right data source';
 is $mysql->username, '',                      'no username';
 is $mysql->password, '',                      'no password';
-my $options = {mysql_enable_utf8 => 1, AutoCommit => 1, AutoInactiveDestroy => 1, PrintError => 0, RaiseError => 1};
+my $options = {mysql_enable_utf8mb4 => 1, AutoCommit => 1, AutoInactiveDestroy => 1, PrintError => 0, RaiseError => 1};
 is_deeply $mysql->options, $options, 'right options';
 
 # Minimal connection string with database
@@ -15,7 +15,7 @@ $mysql = Mojo::mysql->new('mysql:///test1');
 is $mysql->dsn,      'dbi:mysql:dbname=test1', 'right data source';
 is $mysql->username, '',                       'no username';
 is $mysql->password, '',                       'no password';
-$options = {mysql_enable_utf8 => 1, AutoCommit => 1, AutoInactiveDestroy => 1, PrintError => 0, RaiseError => 1};
+$options = {mysql_enable_utf8mb4 => 1, AutoCommit => 1, AutoInactiveDestroy => 1, PrintError => 0, RaiseError => 1};
 is_deeply $mysql->options, $options, 'right options';
 
 # Connection string with host and port
@@ -23,7 +23,7 @@ $mysql = Mojo::mysql->new('mysql://127.0.0.1:8080/test2');
 is $mysql->dsn,      'dbi:mysql:dbname=test2;host=127.0.0.1;port=8080', 'right data source';
 is $mysql->username, '',                                                'no username';
 is $mysql->password, '',                                                'no password';
-$options = {mysql_enable_utf8 => 1, AutoCommit => 1, AutoInactiveDestroy => 1, PrintError => 0, RaiseError => 1};
+$options = {mysql_enable_utf8mb4 => 1, AutoCommit => 1, AutoInactiveDestroy => 1, PrintError => 0, RaiseError => 1};
 is_deeply $mysql->options, $options, 'right options';
 
 # Connection string username but without host
@@ -31,7 +31,7 @@ $mysql = Mojo::mysql->new('mysql://mysql@/test3');
 is $mysql->dsn,      'dbi:mysql:dbname=test3', 'right data source';
 is $mysql->username, 'mysql',                  'right username';
 is $mysql->password, '',                       'no password';
-$options = {mysql_enable_utf8 => 1, AutoCommit => 1, AutoInactiveDestroy => 1, PrintError => 0, RaiseError => 1};
+$options = {mysql_enable_utf8mb4 => 1, AutoCommit => 1, AutoInactiveDestroy => 1, PrintError => 0, RaiseError => 1};
 is_deeply $mysql->options, $options, 'right options';
 
 # Connection string with unix domain socket and options
@@ -39,7 +39,7 @@ $mysql = Mojo::mysql->new('mysql://x1:y2@%2ftmp%2fmysql.sock/test4?PrintError=1&
 is $mysql->dsn,      'dbi:mysql:dbname=test4;host=/tmp/mysql.sock', 'right data source';
 is $mysql->username, 'x1',                                          'right username';
 is $mysql->password, 'y2',                                          'right password';
-$options = {mysql_enable_utf8 => 1, AutoCommit => 1, AutoInactiveDestroy => 1, PrintError => 1, RaiseError => 0};
+$options = {mysql_enable_utf8mb4 => 1, AutoCommit => 1, AutoInactiveDestroy => 1, PrintError => 1, RaiseError => 0};
 is_deeply $mysql->options, $options, 'right options';
 
 # Connection string with lots of zeros
@@ -47,7 +47,7 @@ $mysql = Mojo::mysql->new('mysql://0:0@/0?RaiseError=0');
 is $mysql->dsn,      'dbi:mysql:dbname=0', 'right data source';
 is $mysql->username, '0',                  'right username';
 is $mysql->password, '0',                  'right password';
-$options = {mysql_enable_utf8 => 1, AutoCommit => 1, AutoInactiveDestroy => 1, PrintError => 0, RaiseError => 0};
+$options = {mysql_enable_utf8mb4 => 1, AutoCommit => 1, AutoInactiveDestroy => 1, PrintError => 0, RaiseError => 0};
 is_deeply $mysql->options, $options, 'right options';
 
 # Invalid connection string


### PR DESCRIPTION
The mysql_enable_utf8 sets the utf8 charset which only supports up to 3-byte UTF-8 encodings. mysql_enable_utf8mb4 (as of DBD::mysql 4.032) properly supports encoding unicode characters to up to 4 bytes, such as 𠜎. It means the connection charset will be utf8mb4 (supported back to at least mysql 5.5) and these unicode characters will be supported, but no other changes.