### PR TITLE
Accept Mojo::URL object as input for database URL

### DIFF
--- a/lib/Mojo/mysql.pm
+++ b/lib/Mojo/mysql.pm
@@ -49,7 +49,7 @@ sub from_string {
 
   # Protocol
   return $self unless $str;
-  my $url = Mojo::URL->new($str);
+  my $url = UNIVERSAL::isa($str, "Mojo::URL") ? $str : Mojo::URL->new($str);
   croak qq{Invalid MySQL connection string "$str"} unless $url->protocol eq 'mysql';
 
   # Database

--- a/t/connection.t
+++ b/t/connection.t
@@ -42,6 +42,15 @@ is $mysql->password, 'y2',                                          'right passw
 $options = {mysql_enable_utf8 => 1, AutoCommit => 1, AutoInactiveDestroy => 1, PrintError => 1, RaiseError => 0};
 is_deeply $mysql->options, $options, 'right options';
 
+# Mojo::URL object with credentials
+my $url_obj = Mojo::URL->new('mysql://x2:y3@/test5?PrintError=1');
+$mysql = Mojo::mysql->new($url_obj);
+is $mysql->dsn,      'dbi:mysql:dbname=test5', 'right data source with Mojo::URL object';
+is $mysql->username, 'x2',                     'right username';
+is $mysql->password, 'y3',                     'right password';
+$options = {mysql_enable_utf8 => 1, AutoCommit => 1, AutoInactiveDestroy => 1, PrintError => 1, RaiseError => 1};
+is_deeply $mysql->options, $options, 'right options';
+
 # Connection string with lots of zeros
 $mysql = Mojo::mysql->new('mysql://0:0@/0?RaiseError=0');
 is $mysql->dsn,      'dbi:mysql:dbname=0', 'right data source';


### PR DESCRIPTION
If you send a Mojo::URL object with userinfo to Mojo::mysql->new(), the userinfo will be stripped by Mojo::URL->new(). The stringification of Mojo::URL will strip it. This change will accept Mojo::URL obects as input to new() and use it as is.