### PR TITLE
Add support for mariadb:// and DBD::MariaDB

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,11 @@ perl:
 addons:
   mysql: "5.7"
 before_script:
-  - mysql -e 'create database myapp_test default character set utf8 default collate utf8_general_ci;'
+  - mysql -e 'create database tarvis_ci_mojo_mysql default character set utf8 default collate utf8_general_ci;'
 env:
-  - "HARNESS_OPTIONS=j3 TEST_POD=1 TEST_PUBSUB=1 TEST_FOR=500 TEST_ONLINE=mysql://root@/myapp_test"
+  - "HARNESS_OPTIONS=j3 TEST_POD=1 TEST_PUBSUB=1 TEST_FOR=500 TEST_ONLINE=mysql://root@/tarvis_ci_mojo_mysql"
 install:
-  - "cpanm -n Test::Pod Test::Pod::Coverage"
+  - "cpanm -n DBD::MariaDB Test::Pod Test::Pod::Coverage"
   - "cpanm -n --installdeps ."
 notifications:
   email: false

--- a/lib/Mojo/mysql.pm
+++ b/lib/Mojo/mysql.pm
@@ -25,7 +25,7 @@ has migrations => sub {
 };
 
 has options => sub {
-  my $self = shift;
+  my $self    = shift;
   my $options = {AutoCommit => 1, AutoInactiveDestroy => 1, PrintError => 0, RaiseError => 1};
   $options->{mysql_enable_utf8} = 1 if $self->dsn =~ m!^dbi:mysql:!;
   return $options;
@@ -68,6 +68,10 @@ sub from_string {
   my $url = UNIVERSAL::isa($str, 'Mojo::URL') ? $str : Mojo::URL->new($str);
   croak qq{Invalid MySQL/MariaDB connection string "$str"} unless $url->protocol =~ m!^(mariadb|mysql)$!;
   my $dsn = $url->protocol eq 'mariadb' ? 'dbi:MariaDB' : 'dbi:mysql';
+
+  # https://github.com/jhthorsen/mojo-mysql/pull/47
+  die "DBD::MariaDB 1.21 is required for Mojo::mysql to work properly"
+    if $dsn eq 'dbi:MariaDB' and !eval 'use DBD::MariaDB 1.21;1';
 
   # Database
   $dsn .= ':dbname=' . $url->path->parts->[0] if defined $url->path->parts->[0];
@@ -473,8 +477,8 @@ This method is EXPERIMENTAL and could be removed in future releases.
 Construct a new L<Mojo::mysql> object either from L</ATTRIBUTES> and or parse
 connection string with L</"from_string"> if necessary.
 
-Using the "mariadb" scheme requires the optional module L<DBD::MariaDB> to be
-installed.
+Using the "mariadb" scheme requires the optional module L<DBD::MariaDB> version
+1.21 (or later) to be installed.
 
 =head2 strict_mode
 

--- a/lib/Mojo/mysql.pm
+++ b/lib/Mojo/mysql.pm
@@ -76,7 +76,7 @@ sub from_string {
   if (my $host = $url->host) { $dsn .= file_name_is_absolute($host) ? ";mysql_socket=$host" : ";host=$host" }
   if (my $port = $url->port) { $dsn .= ";port=$port" }
 
-  # Need to set the dsn before settings options
+  # Need to set the dsn before reading options
   $self->dsn($dsn);
 
   # Username and password
@@ -151,7 +151,7 @@ sub _set_strict_mode {
 
 =head1 NAME
 
-Mojo::mysql - Mojolicious and Async MySQL and MariaDB
+Mojo::mysql - Mojolicious and Async MySQL/MariaDB
 
 =head1 SYNOPSIS
 
@@ -165,7 +165,7 @@ Mojo::mysql - Mojolicious and Async MySQL and MariaDB
   # MySQL >= 8.0:
   my $mysql = Mojo::mysql->strict_mode('mysql://username:password@hostname/test;mysql_ssl=1');
 
-  # Connect to MariaDB instead of mysql
+  # Use DBD::MariaDB instead of DBD::mysql
   my $mysql = Mojo::mysql->strict_mode('mariadb://username@/test');
 
   # Create a table
@@ -234,9 +234,14 @@ Mojo::mysql - Mojolicious and Async MySQL and MariaDB
 
 =head1 DESCRIPTION
 
-L<Mojo::mysql> is a tiny wrapper around L<DBD::mysql> that makes
-L<MySQL|http://www.mysql.org> and L<MariaDB|https://mariadb.org/> a lot of fun
-to use with the L<Mojolicious|http://mojolicio.us> real-time web framework.
+L<Mojo::mysql> is a tiny wrapper around L<DBD::mysql> and L<DBD::MariaDB> that
+makes L<MySQL|http://www.mysql.org> and L<MariaDB|https://mariadb.org/> a lot
+of fun to use with the L<Mojolicious|http://mojolicio.us> real-time web
+framework.
+
+The two DBD drivers are compatible with both MySQL and MariaDB, but they offer
+different L</options>. L<DBD::MariaDB> should have better unicode support
+though and might become the default in the future.
 
 Database and handles are cached automatically, so they can be reused
 transparently to increase performance. And you can handle connection timeouts
@@ -371,10 +376,10 @@ Use this feature with caution and remember to always backup your database.
   my $options = $mysql->options;
   $mysql      = $mysql->options({mysql_use_result => 1});
 
-Options for database handles, defaults to activating C<mysql_enable_utf8>, C<AutoCommit>,
-C<AutoInactiveDestroy> as well as C<RaiseError> and deactivating C<PrintError>.
-Note that C<AutoCommit> and C<RaiseError> are considered mandatory, so
-deactivating them would be very dangerous.
+Options for database handles, defaults to activating C<mysql_enable_utf8> (only
+for L<DBD::mysql>), C<AutoCommit>, C<AutoInactiveDestroy> as well as
+C<RaiseError> and deactivating C<PrintError>. C<AutoCommit> and C<RaiseError>
+are considered mandatory, so deactivating them would be very dangerous.
 
 C<mysql_auto_reconnect> is never enabled, L<Mojo::mysql> takes care of dead connections.
 
@@ -382,7 +387,7 @@ C<AutoCommit> cannot not be disabled, use $db->L<begin|Mojo::mysql::Database/"be
 
 C<RaiseError> is enabled for blocking and disabled in event loop for non-blocking queries.
 
-Note about C<mysql_enable_utf8>:
+About C<mysql_enable_utf8>:
 
   The mysql_enable_utf8 sets the utf8 charset which only supports up to 3-byte
   UTF-8 encodings. mysql_enable_utf8mb4 (as of DBD::mysql 4.032) properly
@@ -468,7 +473,7 @@ This method is EXPERIMENTAL and could be removed in future releases.
 Construct a new L<Mojo::mysql> object either from L</ATTRIBUTES> and or parse
 connection string with L</"from_string"> if necessary.
 
-Connecting to MariaDB requires the optional module L<DBD::MariaDB> to be
+Using the "mariadb" scheme requires the optional module L<DBD::MariaDB> to be
 installed.
 
 =head2 strict_mode

--- a/lib/Mojo/mysql/Database.pm
+++ b/lib/Mojo/mysql/Database.pm
@@ -16,7 +16,7 @@ has results_class => 'Mojo::mysql::Results';
 for my $name (qw(delete insert select update)) {
   monkey_patch __PACKAGE__, $name, sub {
     my $self = shift;
-    my @cb = ref $_[-1] eq 'CODE' ? pop : ();
+    my @cb   = ref $_[-1] eq 'CODE' ? pop : ();
     return $self->query($self->mysql->abstract->$name(@_), @cb);
   };
   monkey_patch __PACKAGE__, "${name}_p", sub {
@@ -36,7 +36,7 @@ sub backlog { scalar @{shift->{waiting} || []} }
 
 sub begin {
   my $self = shift;
-  my $tx = Mojo::mysql::Transaction->new(db => $self);
+  my $tx   = Mojo::mysql::Transaction->new(db => $self);
   weaken $tx->{db};
   return $tx;
 }
@@ -48,7 +48,7 @@ sub disconnect {
   $self->dbh->disconnect;
 }
 
-sub pid { $_[0]->mysql->handle_attr($_[0]->dbh, 'thread_id') }
+sub pid { $_[0]->mysql->_dbi_attr($_[0]->dbh, 'thread_id') }
 
 sub ping { shift->dbh->ping }
 
@@ -62,7 +62,7 @@ sub query {
     my $sth = $self->dbh->prepare($query);
     local $sth->{HandleError} = sub { $_[0] = Carp::shortmess($_[0]); 0 };
     _bind_params($sth, @_);
-    my $rv = $sth->execute;
+    my $rv  = $sth->execute;
     my $res = $self->results_class->new(db => $self, sth => $sth);
     $res->{affected_rows} = defined $rv && $rv >= 0 ? 0 + $rv : undef;
     return $res;

--- a/lib/Mojo/mysql/Database.pm
+++ b/lib/Mojo/mysql/Database.pm
@@ -48,7 +48,7 @@ sub disconnect {
   $self->dbh->disconnect;
 }
 
-sub pid { shift->dbh->{mysql_thread_id} }
+sub pid { $_[0]->mysql->handle_attr($_[0]->dbh, 'thread_id') }
 
 sub ping { shift->dbh->ping }
 
@@ -120,7 +120,9 @@ sub _next {
   return unless my $next = $self->{waiting}[0];
   return if $next->{sth};
 
-  my $sth = $next->{sth} = $self->dbh->prepare($next->{query}, {async => 1});
+  my $dbh  = $self->dbh;
+  my $flag = lc $dbh->{Driver}{Name} eq 'mariadb' ? 'mariadb_async' : 'async';
+  my $sth  = $next->{sth} = $self->dbh->prepare($next->{query}, {$flag => 1});
   _bind_params($sth, @{$next->{args}});
   $sth->execute;
 }
@@ -133,16 +135,20 @@ sub _watch {
   my $self = shift;
   return if $self->{handle};
 
-  my $dbh = $self->dbh;
-  open $self->{handle}, '<&', $dbh->mysql_fd or die "Dup mysql_fd: $!";
+  my $dbh           = $self->dbh;
+  my $driver        = lc $dbh->{Driver}{Name};
+  my $ready_method  = "${driver}_async_ready";
+  my $result_method = "${driver}_async_result";
+  my $fd            = $driver eq 'mariadb' ? $dbh->mariadb_sockfd : $dbh->mysql_fd;
+  open $self->{handle}, '<&', $fd or die "Could not dup $driver fd: $!";
   Mojo::IOLoop->singleton->reactor->io(
     $self->{handle} => sub {
       return unless my $waiting = $self->{waiting};
-      return unless @$waiting and $waiting->[0]{sth} and $waiting->[0]{sth}->mysql_async_ready;
+      return unless @$waiting and $waiting->[0]{sth} and $waiting->[0]{sth}->$ready_method;
       my ($cb, $err, $sth) = @{shift @$waiting}{qw(cb err sth)};
 
       # Do not raise exceptions inside the event loop
-      my $rv = do { local $sth->{RaiseError} = 0; $sth->mysql_async_result; };
+      my $rv = do { local $sth->{RaiseError} = 0; $sth->$result_method };
       my $res = $self->results_class->new(db => $self, sth => $sth);
 
       $err = undef if defined $rv;

--- a/lib/Mojo/mysql/Results.pm
+++ b/lib/Mojo/mysql/Results.pm
@@ -29,9 +29,9 @@ sub more_results { shift->sth->more_results }
 
 sub affected_rows { shift->{affected_rows} }
 
-sub warnings_count { shift->sth->{mysql_warning_count} }
+sub warnings_count { $_[0]->db->mysql->handle_attr($_[0]->sth, 'warning_count') }
 
-sub last_insert_id { shift->sth->{mysql_insertid} }
+sub last_insert_id { $_[0]->db->mysql->handle_attr($_[0]->sth, 'insertid') }
 
 sub err { shift->sth->err }
 
@@ -56,7 +56,7 @@ sub _expand {
   # Only expand json columns
   my ($idx, $name) = @$self{qw(idx name)};
   unless ($idx) {
-    my $types = $self->sth->{mysql_type};
+    my $types = $self->db->mysql->handle_attr($self->sth, 'type');
     my @idx = grep { $types->[$_] == 245 or $types->[$_] == 252 } 0 .. $#$types;    # 245 = MySQL, 252 = MariaDB
     ($idx, $name) = @$self{qw(idx name)} = (\@idx, [@{$self->columns}[@idx]]);
   }
@@ -227,11 +227,13 @@ Handle multiple results.
   my $affected = $results->affected_rows;
 
 Number of affected rows by the query. The number reported is dependant from
-C<mysql_client_found_rows> option in L<Mojo::mysql>. For example
+C<mysql_client_found_rows> or C<mariadb_client_found_rows> option in
+L<Mojo::mysql>. For example
 
   UPDATE $table SET id = 1 WHERE id = 1
 
-would return 1 if C<mysql_client_found_rows> is set, and 0 otherwise.
+would return 1 if C<mysql_client_found_rows> or L<mariadb_client_found_rows> is
+set, and 0 otherwise.
 
 =head2 last_insert_id
 

--- a/lib/Mojo/mysql/Results.pm
+++ b/lib/Mojo/mysql/Results.pm
@@ -29,9 +29,9 @@ sub more_results { shift->sth->more_results }
 
 sub affected_rows { shift->{affected_rows} }
 
-sub warnings_count { $_[0]->db->mysql->handle_attr($_[0]->sth, 'warning_count') }
+sub warnings_count { $_[0]->db->mysql->_dbi_attr($_[0]->sth, 'warning_count') }
 
-sub last_insert_id { $_[0]->db->mysql->handle_attr($_[0]->sth, 'insertid') }
+sub last_insert_id { $_[0]->db->mysql->_dbi_attr($_[0]->sth, 'insertid') }
 
 sub err { shift->sth->err }
 
@@ -56,8 +56,8 @@ sub _expand {
   # Only expand json columns
   my ($idx, $name) = @$self{qw(idx name)};
   unless ($idx) {
-    my $types = $self->db->mysql->handle_attr($self->sth, 'type');
-    my @idx = grep { $types->[$_] == 245 or $types->[$_] == 252 } 0 .. $#$types;    # 245 = MySQL, 252 = MariaDB
+    my $types = $self->db->mysql->_dbi_attr($self->sth, 'type');
+    my @idx   = grep { $types->[$_] == 245 or $types->[$_] == 252 } 0 .. $#$types;    # 245 = MySQL, 252 = MariaDB
     ($idx, $name) = @$self{qw(idx name)} = (\@idx, [@{$self->columns}[@idx]]);
   }
 

--- a/t/connection.t
+++ b/t/connection.t
@@ -67,7 +67,7 @@ is_deeply $mysql->options, $options, 'right options';
 
 note 'Invalid connection string';
 eval { Mojo::mysql->new('http://localhost:3000/test') };
-like $@, qr/Invalid MySQL connection string/, 'right error';
+like $@, qr{Invalid MySQL/MariaDB connection string}, 'right error';
 
 note 'Quote fieldnames correctly';
 like $mysql->abstract->select("foo", ['binary']),     qr{`binary},       'quoted correct binary';

--- a/t/crud.t
+++ b/t/crud.t
@@ -22,7 +22,7 @@ $db->query(
 note 'Create';
 $db->insert('crud_test', {name => 'foo'});
 is_deeply $db->select('crud_test')->hashes->to_array, [{id => 1, name => 'foo'}], 'right structure';
-is $db->insert('crud_test', {name => 'bar'})->sth->{mysql_insertid}, 2, 'right value';
+is $db->mysql->handle_attr($db->insert('crud_test', {name => 'bar'})->sth, 'insertid'), 2, 'right value';
 is_deeply $db->select('crud_test')->hashes->to_array, [{id => 1, name => 'foo'}, {id => 2, name => 'bar'}],
   'right structure';
 

--- a/t/crud.t
+++ b/t/crud.t
@@ -22,7 +22,7 @@ $db->query(
 note 'Create';
 $db->insert('crud_test', {name => 'foo'});
 is_deeply $db->select('crud_test')->hashes->to_array, [{id => 1, name => 'foo'}], 'right structure';
-is $db->mysql->handle_attr($db->insert('crud_test', {name => 'bar'})->sth, 'insertid'), 2, 'right value';
+is $db->mysql->_dbi_attr($db->insert('crud_test', {name => 'bar'})->sth, 'insertid'), 2, 'right value';
 is_deeply $db->select('crud_test')->hashes->to_array, [{id => 1, name => 'foo'}, {id => 2, name => 'bar'}],
   'right structure';
 
@@ -41,7 +41,7 @@ $db->select('crud_test', $delay->begin);
 $delay->wait;
 is_deeply $result, [{id => 1, name => 'foo'}, {id => 2, name => 'bar'}], 'right structure';
 $result = undef;
-$delay = Mojo::IOLoop->delay(sub { $result = pop->hashes->to_array });
+$delay  = Mojo::IOLoop->delay(sub { $result = pop->hashes->to_array });
 $db->select('crud_test', undef, undef, {-desc => 'id'}, $delay->begin);
 $delay->wait;
 is_deeply $result, [{id => 2, name => 'bar'}, {id => 1, name => 'foo'}], 'right structure';

--- a/t/mariadb.t
+++ b/t/mariadb.t
@@ -7,8 +7,7 @@ $ENV{TEST_ONLINE} =~ s!mysql:!mariadb:!
   if $ENV{TEST_ONLINE} and $ENV{TEST_ONLINE} eq 'mysql://root@/tarvis_ci_mojo_mysql';
 
 plan skip_all => 'TEST_ONLINE=mariadb://root@/test' unless $ENV{TEST_ONLINE} and $ENV{TEST_ONLINE} =~ m!^mariadb:!;
-
-my $mysql = Mojo::mysql->new($ENV{TEST_ONLINE});
+plan skip_all => $@ unless my $mysql = eval { Mojo::mysql->new($ENV{TEST_ONLINE}) };
 
 ok $mysql->db->ping, 'connected';
 is $mysql->db->dbh->{Driver}{Name}, 'MariaDB', 'driver name';

--- a/t/mariadb.t
+++ b/t/mariadb.t
@@ -1,0 +1,16 @@
+use Mojo::Base -strict;
+use Test::More;
+use Mojo::mysql;
+
+# special case for travis
+$ENV{TEST_ONLINE} =~ s!mysql:!mariadb:!
+  if $ENV{TEST_ONLINE} and $ENV{TEST_ONLINE} eq 'mysql://root@/tarvis_ci_mojo_mysql';
+
+plan skip_all => 'TEST_ONLINE=mariadb://root@/test' unless $ENV{TEST_ONLINE} and $ENV{TEST_ONLINE} =~ m!^mariadb:!;
+
+my $mysql = Mojo::mysql->new($ENV{TEST_ONLINE});
+
+ok $mysql->db->ping, 'connected';
+is $mysql->db->dbh->{Driver}{Name}, 'MariaDB', 'driver name';
+
+done_testing;

--- a/t/mysql.t
+++ b/t/mysql.t
@@ -1,0 +1,12 @@
+use Mojo::Base -strict;
+use Test::More;
+use Mojo::mysql;
+
+plan skip_all => 'TEST_ONLINE=mysql://root@/test' unless $ENV{TEST_ONLINE} and $ENV{TEST_ONLINE} =~ m!^mysql:!;
+
+my $mysql = Mojo::mysql->new($ENV{TEST_ONLINE});
+
+ok $mysql->db->ping, 'connected';
+is $mysql->db->dbh->{Driver}{Name}, 'mysql', 'driver name';
+
+done_testing;

--- a/t/mysql_auto_reconnect.t
+++ b/t/mysql_auto_reconnect.t
@@ -10,6 +10,6 @@ $ENV{MOD_PERL} = 1;
 
 my $mysql = Mojo::mysql->new($ENV{TEST_ONLINE});
 ok $mysql->db->ping, 'connected';
-is $mysql->db->dbh->{mysql_auto_reconnect}, 0, 'mysql_auto_reconnect=0';
+ok !$mysql->handle_attr($mysql->db->dbh, 'auto_reconnect'), 'auto_reconnect';
 
 done_testing;

--- a/t/mysql_auto_reconnect.t
+++ b/t/mysql_auto_reconnect.t
@@ -10,6 +10,6 @@ $ENV{MOD_PERL} = 1;
 
 my $mysql = Mojo::mysql->new($ENV{TEST_ONLINE});
 ok $mysql->db->ping, 'connected';
-ok !$mysql->handle_attr($mysql->db->dbh, 'auto_reconnect'), 'auto_reconnect';
+ok !$mysql->_dbi_attr($mysql->db->dbh, 'auto_reconnect'), 'auto_reconnect';
 
 done_testing;

--- a/t/results_methods.t
+++ b/t/results_methods.t
@@ -8,7 +8,8 @@ use Mojo::IOLoop;
 use Mojo::mysql;
 
 my $mysql = Mojo::mysql->new($ENV{TEST_ONLINE});
-$mysql->options->{mysql_client_found_rows} = 0;
+my $driver = $ENV{TEST_ONLINE} =~ m!^(\w+):! ? $1 : 'mysql';
+$mysql->options->{"${driver}_client_found_rows"} = 0;
 my $db = $mysql->db;
 $db->query(
   'create table if not exists results_test (
@@ -46,7 +47,7 @@ like $res->hashes->[0]->{Message}, qr/Truncated/, 'warning message';
 
 $db->disconnect;
 
-$mysql->options->{mysql_client_found_rows} = 1;
+$mysql->options->{"${driver}_client_found_rows"} = 1;
 $db = $mysql->db;
 
 is $db->query('update results_test set name=? where name=?', 'foo', 'foo1')->affected_rows, 0, 'right affected rows';


### PR DESCRIPTION
I'm not entirely sure if there should be a Mojo::MariaDB or if I could add support for MariaDB directly into Mojo::mysql.

Keeping this PR open for input from the public for now.