### PR TITLE
Initialize SSL connection to MySQL 8

### DIFF
--- a/lib/Mojo/mysql.pm
+++ b/lib/Mojo/mysql.pm
@@ -146,7 +146,7 @@ Mojo::mysql - Mojolicious and Async MySQL
 
   # Connect to a remote database
   my $mysql = Mojo::mysql->strict_mode('mysql://username:password@hostname/test');
-  # MySQL >= 8.0:
+  # MySQL >= 8.0, initial connection for username:
   my $mysql = Mojo::mysql->strict_mode('mysql://username:password@hostname/test;mysql_ssl=1');
 
   # Create a table

--- a/t/01-init.t
+++ b/t/01-init.t
@@ -1,0 +1,22 @@
+use Mojo::Base -strict;
+use Mojo::mysql;
+use Test::More;
+
+plan skip_all => 'TEST_ONLINE=mysql://root@/test' unless $ENV{TEST_ONLINE};
+
+my $mysql = Mojo::mysql->new($ENV{TEST_ONLINE});
+my $db;
+
+eval { $db = $mysql->db; };
+if ($@) {
+  die $@ unless $@ =~ /Authentication requires secure connection/;
+
+  # assume we are on MySQL 8 and try again with SSL
+  $mysql = Mojo::mysql->new("$ENV{TEST_ONLINE};mysql_ssl=1");
+  ok $db = $mysql->db, 'SSL connection established';
+}
+else {
+  pass 'connection established';
+}
+
+done_testing;


### PR DESCRIPTION
Connections to MySQL 8 are a bit more complicated/sophisticated. The idea of the new caching_sha2_password authentication method is that we only need the overhead of SSL for the first connection of a user. This is used in `t/01-init.t`, so tests on MySQL 8 can be run without additional parameters. Maybe somewhere in the future DBD::mysql will handle this automatically.