### PR TITLE
Fix last_insert_id and other sth_attrs in Results

### DIFF
--- a/lib/Mojo/mysql/Results.pm
+++ b/lib/Mojo/mysql/Results.pm
@@ -88,7 +88,6 @@ sub _from_json_mode_2_hash {
 sub _sth_attr {
   my ($self, $name) = @_;
   $name =~ s!^mysql!{lc $self->db->dbh->{Driver}{Name}}!e;
-  return $self->sth->{$name} = shift if @_;
   return $self->sth->{$name};
 }
 


### PR DESCRIPTION
This line seems to be for the purpose of setting a value to the attribute, but this is never done with _sth_attr (only _dbh_attr) and is broken because $self and $name still remain in `@_` so this line will always run, attempting to set the attr to undef. This causes an error in the case of readonly attributes like mariadb_insertid, or would cause issues in other code where attr should not be set to undef.