### PR TITLE
PubSub retry also on deadlock

### DIFF
--- a/lib/Mojo/mysql/PubSub.pm
+++ b/lib/Mojo/mysql/PubSub.pm
@@ -137,10 +137,13 @@ sub _query_with_retry {
     # first line to avoid potential spurious matches if the error
     # e.g. contains a stack trace.
     my $err = $@;                                        # avoid stringifying $@ ...
-    croak $@ unless $err =~ /^\V*(?:retry|timeout)/i;    # ... and maybe rethrow it
-
-    # If we got here, we are retrying the query:
-    warn qq|[PubSub] (@{[$db->pid]}) retry ($sql) !!! $err\n| if DEBUG;
+    if ($err =~ /^\V*(?:retry|timeout|try restart)/i) {  # ... and maybe rethrow it
+      # If we got here, we are retrying the query:
+      warn qq|[PubSub] (@{[$db->pid]}) retry ($sql) !!! $err\n| if DEBUG;
+    } else {
+      warn qq|[PubSub] (@{[$db->pid]}) noretry ($sql) !!! $err\n| if DEBUG;
+      croak $@;
+    }
   }
 
   return $result;


### PR DESCRIPTION
1. Always log failed error message in retry when PUBSUB_DEBUG is enabled.

After that I started seeing in debug output:
```
[PubSub] (6093845) noretry (insert into mojo_pubsub_subscribe (pid, channel) values (?, ?) on duplicate key update ts=current_timestamp) !!! DBD::mysql::st execute failed: Deadlock found when trying to get lock; try restarting transaction
```

2. Retry when DB reports a deadlock.

See also report about deadlock in https://jira.mariadb.org/browse/MDEV-31017 